### PR TITLE
feat: サービスメッシュ、CI/CD、テンプレート、Terraform、観測性の改善

### DIFF
--- a/CLI/src/template/context.rs
+++ b/CLI/src/template/context.rs
@@ -69,6 +69,8 @@ pub struct TemplateContext {
     pub docker_registry: String,
     /// Docker プロジェクト名 (自動導出: "k1s0-{tier}")
     pub docker_project: String,
+    /// Helm Chart の Tier 別相対パス (自動導出: "{service_name}")
+    pub helm_path: String,
 }
 
 /// TemplateContext を構築するためのビルダー。
@@ -223,6 +225,9 @@ impl TemplateContextBuilder {
         // docker_project の導出: "k1s0-{tier}"
         let docker_project = format!("k1s0-{}", self.tier);
 
+        // helm_path の導出: service_name をそのまま使用
+        let helm_path = self.service_name.clone();
+
         // api_style: 後方互換のため api_styles の先頭要素を設定
         let api_style = self.api_styles.first().cloned().unwrap_or_default();
 
@@ -247,6 +252,7 @@ impl TemplateContextBuilder {
             rust_crate,
             docker_registry: self.docker_registry,
             docker_project,
+            helm_path,
         }
     }
 }
@@ -278,6 +284,7 @@ impl TemplateContext {
         ctx.insert("rust_crate", &self.rust_crate);
         ctx.insert("docker_registry", &self.docker_registry);
         ctx.insert("docker_project", &self.docker_project);
+        ctx.insert("helm_path", &self.helm_path);
         ctx
     }
 }
@@ -695,6 +702,7 @@ mod tests {
         assert_eq!(ctx.rust_crate, "");
         assert_eq!(ctx.docker_registry, "harbor.internal.example.com");
         assert_eq!(ctx.docker_project, "k1s0-service");
+        assert_eq!(ctx.helm_path, "order-api");
     }
 
     #[test]
@@ -756,6 +764,7 @@ mod tests {
         assert_eq!(json["rust_crate"], "");
         assert_eq!(json["docker_registry"], "harbor.internal.example.com");
         assert_eq!(json["docker_project"], "k1s0-service");
+        assert_eq!(json["helm_path"], "order-api");
     }
 
     #[test]

--- a/CLI/src/template/mod.rs
+++ b/CLI/src/template/mod.rs
@@ -89,7 +89,12 @@ impl TemplateEngine {
         let tera_ctx = ctx.to_tera_context();
 
         // kind + language に対応するテンプレートディレクトリを決定
-        let kind_lang_dir = self.template_dir.join(&ctx.kind).join(&ctx.language);
+        // CICD テンプレートは言語サブディレクトリを持たないフラット構造
+        let kind_lang_dir = if ctx.kind == "cicd" {
+            self.template_dir.join(&ctx.kind)
+        } else {
+            self.template_dir.join(&ctx.kind).join(&ctx.language)
+        };
         if !kind_lang_dir.exists() {
             anyhow::bail!(
                 "テンプレートディレクトリが見つかりません: {}",

--- a/CLI/tests/client_template_rendering.rs
+++ b/CLI/tests/client_template_rendering.rs
@@ -256,3 +256,48 @@ fn test_client_flutter_service_name_substitution() {
     // service_name_pascal が正しく "TestApp" に置換されている
     assert!(main.contains("title: 'TestApp'"));
 }
+
+// =========================================================================
+// クライアント: README, テストファイル内容検証
+// =========================================================================
+
+#[test]
+fn test_client_react_readme_content() {
+    let (tmp, _) = render_client("react");
+    let content = read_output(&tmp, "README.md");
+
+    assert!(content.contains("test-app"));
+}
+
+#[test]
+fn test_client_react_app_test_content() {
+    let (tmp, _) = render_client("react");
+    let content = read_output(&tmp, "tests/App.test.tsx");
+
+    assert!(!content.is_empty());
+}
+
+#[test]
+fn test_client_react_msw_setup_content() {
+    let (tmp, _) = render_client("react");
+    let content = read_output(&tmp, "tests/testutil/msw-setup.ts");
+
+    assert!(content.contains("setupServer"));
+    assert!(content.contains("msw"));
+}
+
+#[test]
+fn test_client_flutter_readme_content() {
+    let (tmp, _) = render_client("flutter");
+    let content = read_output(&tmp, "README.md");
+
+    assert!(content.contains("test-app") || content.contains("TestApp") || content.contains("test_app"));
+}
+
+#[test]
+fn test_client_flutter_widget_test_content() {
+    let (tmp, _) = render_client("flutter");
+    let content = read_output(&tmp, "test/widget_test.dart");
+
+    assert!(!content.is_empty());
+}

--- a/CLI/tests/helm_template_rendering.rs
+++ b/CLI/tests/helm_template_rendering.rs
@@ -227,6 +227,60 @@ fn test_helm_values_prod() {
 }
 
 #[test]
+fn test_helm_values_staging() {
+    let Some((tmp, _)) = render_helm("go", "rest", true, false, false) else {
+        eprintln!("SKIP: helm/go テンプレートディレクトリが未作成");
+        return;
+    };
+
+    let content = read_output(&tmp, "values-staging.yaml");
+    assert!(content.contains("replicaCount:") || content.contains("replica"));
+    assert!(content.contains("staging") || content.contains("autoscaling"));
+}
+
+#[test]
+fn test_helm_configmap() {
+    let Some((tmp, _)) = render_helm("go", "rest", false, false, false) else {
+        eprintln!("SKIP: helm/go テンプレートディレクトリが未作成");
+        return;
+    };
+
+    let content = read_output(&tmp, "configmap.yaml");
+    assert!(
+        content.contains("k1s0-common.configmap") || content.contains("ConfigMap"),
+        "configmap.yaml should reference k1s0-common.configmap"
+    );
+}
+
+#[test]
+fn test_helm_hpa() {
+    let Some((tmp, _)) = render_helm("go", "rest", false, false, false) else {
+        eprintln!("SKIP: helm/go テンプレートディレクトリが未作成");
+        return;
+    };
+
+    let content = read_output(&tmp, "hpa.yaml");
+    assert!(
+        content.contains("k1s0-common.hpa") || content.contains("HorizontalPodAutoscaler"),
+        "hpa.yaml should reference k1s0-common.hpa"
+    );
+}
+
+#[test]
+fn test_helm_pdb() {
+    let Some((tmp, _)) = render_helm("go", "rest", false, false, false) else {
+        eprintln!("SKIP: helm/go テンプレートディレクトリが未作成");
+        return;
+    };
+
+    let content = read_output(&tmp, "pdb.yaml");
+    assert!(
+        content.contains("k1s0-common.pdb") || content.contains("PodDisruptionBudget"),
+        "pdb.yaml should reference k1s0-common.pdb"
+    );
+}
+
+#[test]
 fn test_helm_no_tera_syntax() {
     let Some((tmp, names)) = render_helm("go", "rest", true, true, true) else {
         eprintln!("SKIP: helm/go テンプレートディレクトリが未作成");

--- a/docs/ディレクトリ構成図.md
+++ b/docs/ディレクトリ構成図.md
@@ -64,7 +64,7 @@ CLI/
 │   ├── library/
 │   │   ├── go/
 │   │   ├── rust/
-│   │   ├── ts/
+│   │   ├── typescript/
 │   │   └── dart/
 │   └── database/
 ├── Cargo.toml
@@ -95,7 +95,7 @@ regions/system/
 │   ├── rust/
 │   │   └── {ライブラリ名}/
 │   │       └── （Rust ライブラリ構成）
-│   ├── ts/
+│   ├── typescript/
 │   │   └── {ライブラリ名}/
 │   │       └── （TypeScript ライブラリ構成）
 │   └── dart/
@@ -134,7 +134,7 @@ regions/business/
     │   ├── rust/
     │   │   └── {ライブラリ名}/
     │   │       └── （Rust ライブラリ構成）
-    │   ├── ts/
+    │   ├── typescript/
     │   │   └── {ライブラリ名}/
     │   │       └── （TypeScript ライブラリ構成）
     │   └── dart/

--- a/e2e/tests/docs_compliance/test_coding_standards.py
+++ b/e2e/tests/docs_compliance/test_coding_standards.py
@@ -161,3 +161,148 @@ class TestClippyLints:
         assert "pedantic" in content
         assert "module_name_repetitions" in content
         assert "must_use_candidate" in content
+
+
+class TestEslintConfigRules:
+    """コーディング規約.md: eslint.config.mjs 具体ルールの検証。"""
+
+    def setup_method(self) -> None:
+        path = ROOT / "eslint.config.mjs"
+        assert path.exists(), "eslint.config.mjs が存在しません"
+        self.content = path.read_text(encoding="utf-8")
+
+    def test_react_hooks_rules_of_hooks(self) -> None:
+        """コーディング規約.md: react-hooks/rules-of-hooks: error。"""
+        assert "react-hooks/rules-of-hooks" in self.content
+
+    def test_react_hooks_exhaustive_deps(self) -> None:
+        """コーディング規約.md: react-hooks/exhaustive-deps: warn。"""
+        assert "react-hooks/exhaustive-deps" in self.content
+
+    def test_import_order_rule(self) -> None:
+        """コーディング規約.md: import/order ルールが設定されている。"""
+        assert "import/order" in self.content
+
+    def test_no_unused_vars_rule(self) -> None:
+        """コーディング規約.md: @typescript-eslint/no-unused-vars: error。"""
+        assert "@typescript-eslint/no-unused-vars" in self.content
+
+    def test_no_floating_promises_rule(self) -> None:
+        """コーディング規約.md: @typescript-eslint/no-floating-promises: error。"""
+        assert "@typescript-eslint/no-floating-promises" in self.content
+
+    def test_strict_type_checked(self) -> None:
+        """コーディング規約.md: strictTypeChecked が有効。"""
+        assert "strictTypeChecked" in self.content
+
+
+class TestPrettierrcConfig:
+    """コーディング規約.md: .prettierrc 具体設定の検証。"""
+
+    def setup_method(self) -> None:
+        import json
+        path = ROOT / ".prettierrc"
+        assert path.exists(), ".prettierrc が存在しません"
+        self.content = path.read_text(encoding="utf-8")
+        self.config = json.loads(self.content)
+
+    def test_semi_true(self) -> None:
+        """コーディング規約.md: semi: true。"""
+        assert self.config["semi"] is True
+
+    def test_single_quote_true(self) -> None:
+        """コーディング規約.md: singleQuote: true。"""
+        assert self.config["singleQuote"] is True
+
+    def test_trailing_comma_all(self) -> None:
+        """コーディング規約.md: trailingComma: all。"""
+        assert self.config["trailingComma"] == "all"
+
+    def test_print_width_100(self) -> None:
+        """コーディング規約.md: printWidth: 100。"""
+        assert self.config["printWidth"] == 100
+
+    def test_tab_width_2(self) -> None:
+        """コーディング規約.md: tabWidth: 2。"""
+        assert self.config["tabWidth"] == 2
+
+
+class TestDartAnalysisOptionsRules:
+    """コーディング規約.md: analysis_options.yaml 具体ルールの検証。"""
+
+    def setup_method(self) -> None:
+        path = ROOT / "analysis_options.yaml"
+        assert path.exists(), "analysis_options.yaml が存在しません"
+        self.content = path.read_text(encoding="utf-8")
+        self.config = yaml.safe_load(self.content)
+
+    def test_prefer_const_constructors(self) -> None:
+        """コーディング規約.md: prefer_const_constructors ルール。"""
+        assert "prefer_const_constructors" in self.config["linter"]["rules"]
+
+    def test_prefer_const_declarations(self) -> None:
+        """コーディング規約.md: prefer_const_declarations ルール。"""
+        assert "prefer_const_declarations" in self.config["linter"]["rules"]
+
+    def test_avoid_print(self) -> None:
+        """コーディング規約.md: avoid_print ルール。"""
+        assert "avoid_print" in self.config["linter"]["rules"]
+
+    def test_prefer_single_quotes(self) -> None:
+        """コーディング規約.md: prefer_single_quotes ルール。"""
+        assert "prefer_single_quotes" in self.config["linter"]["rules"]
+
+    def test_flutter_lints_include(self) -> None:
+        """コーディング規約.md: flutter_lints パッケージを include。"""
+        assert "flutter_lints" in self.content
+
+
+class TestVitestConfigTemplate:
+    """コーディング規約.md: vitest.config.ts テンプレート仕様の検証。"""
+
+    def test_vitest_spec_in_doc(self) -> None:
+        """コーディング規約.md: vitest.config.ts 仕様がドキュメントに記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "vitest" in content.lower()
+        assert "defineConfig" in content
+
+    def test_vitest_globals_true_in_doc(self) -> None:
+        """コーディング規約.md: globals: true が仕様に記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "globals: true" in content
+
+    def test_vitest_jsdom_environment_in_doc(self) -> None:
+        """コーディング規約.md: environment: jsdom が仕様に記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "jsdom" in content
+
+    def test_vitest_v8_coverage_in_doc(self) -> None:
+        """コーディング規約.md: coverage provider v8 が仕様に記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "v8" in content
+
+
+class TestGoTestToolsConfig:
+    """コーディング規約.md: Go テストツール（testify, gomock）の検証。"""
+
+    def test_testify_in_doc(self) -> None:
+        """コーディング規約.md: testify がドキュメントに記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "testify" in content
+
+    def test_gomock_in_doc(self) -> None:
+        """コーディング規約.md: gomock がドキュメントに記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "gomock" in content
+
+    def test_mockall_in_doc(self) -> None:
+        """コーディング規約.md: Rust mockall がドキュメントに記載。"""
+        doc = ROOT / "docs" / "コーディング規約.md"
+        content = doc.read_text(encoding="utf-8")
+        assert "mockall" in content

--- a/e2e/tests/docs_compliance/test_devcontainer.py
+++ b/e2e/tests/docs_compliance/test_devcontainer.py
@@ -111,6 +111,38 @@ class TestDevcontainerConfig:
         settings = self.config["customizations"]["vscode"]["settings"]
         assert settings["editor.formatOnSave"] is True
 
+    def test_code_actions_on_save(self) -> None:
+        """devcontainer設計.md: codeActionsOnSave の設定検証。"""
+        settings = self.config["customizations"]["vscode"]["settings"]
+        actions = settings["editor.codeActionsOnSave"]
+        assert actions["source.fixAll"] == "explicit"
+        assert actions["source.organizeImports"] == "explicit"
+
+    def test_go_default_formatter(self) -> None:
+        """devcontainer設計.md: Go の defaultFormatter 設定。"""
+        settings = self.config["customizations"]["vscode"]["settings"]
+        assert settings["[go]"]["editor.defaultFormatter"] == "golang.go"
+
+    def test_rust_default_formatter(self) -> None:
+        """devcontainer設計.md: Rust の defaultFormatter 設定。"""
+        settings = self.config["customizations"]["vscode"]["settings"]
+        assert settings["[rust]"]["editor.defaultFormatter"] == "rust-lang.rust-analyzer"
+
+    def test_typescript_default_formatter(self) -> None:
+        """devcontainer設計.md: TypeScript の defaultFormatter 設定。"""
+        settings = self.config["customizations"]["vscode"]["settings"]
+        assert settings["[typescript][typescriptreact]"]["editor.defaultFormatter"] == "esbenp.prettier-vscode"
+
+    def test_dart_default_formatter(self) -> None:
+        """devcontainer設計.md: Dart の defaultFormatter 設定。"""
+        settings = self.config["customizations"]["vscode"]["settings"]
+        assert settings["[dart]"]["editor.defaultFormatter"] == "Dart-Code.dart-code"
+
+    def test_python_default_formatter(self) -> None:
+        """devcontainer設計.md: Python の defaultFormatter 設定。"""
+        settings = self.config["customizations"]["vscode"]["settings"]
+        assert settings["[python]"]["editor.defaultFormatter"] == "charliermarsh.ruff"
+
 
 class TestDevcontainerExtendCompose:
     """devcontainer設計.md: docker-compose.extend.yaml の検証。"""
@@ -170,3 +202,9 @@ class TestPostCreateScript:
         script = ROOT / ".devcontainer" / "post-create.sh"
         content = script.read_text(encoding="utf-8")
         assert "buf" in content
+
+    def test_post_create_installs_protobuf_compiler(self) -> None:
+        """devcontainer設計.md: protobuf-compiler がインストールされること。"""
+        script = ROOT / ".devcontainer" / "post-create.sh"
+        content = script.read_text(encoding="utf-8")
+        assert "protobuf-compiler" in content

--- a/e2e/tests/docs_compliance/test_directory_structure.py
+++ b/e2e/tests/docs_compliance/test_directory_structure.py
@@ -179,3 +179,319 @@ class TestGitHubWorkflows:
         assert (
             ROOT / ".github" / "workflows" / workflow
         ).exists(), f".github/workflows/{workflow} が存在しません"
+
+
+# ============================================================================
+# tier-architecture.md ギャップ補完テスト
+# ============================================================================
+
+CLI_SRC = ROOT / "CLI" / "src"
+TEMPLATES = ROOT / "CLI" / "templates"
+
+
+class TestTierDependencyDirection:
+    """tier-architecture.md: 依存方向検証テスト。
+
+    依存は下位→上位の一方向のみ許可する。逆方向の依存は禁止。
+    Go import パス / Rust Cargo.toml 依存が逆方向参照していないことをチェック。
+    """
+
+    def test_go_template_no_reverse_dependency_comment(self) -> None:
+        """tier-architecture.md: Go サーバーテンプレートに依存方向ルールのコメントが含まれる。"""
+        content = (TEMPLATES / "server" / "go" / "go.mod.tera").read_text(encoding="utf-8")
+        # go.mod テンプレートにはモジュールパスがあるが、
+        # 逆方向参照（system が business/service に依存）がないことを確認
+        # system テンプレートが business/service をインポートしていないこと
+        assert "{{ go_module }}" in content
+        # 逆方向参照パターンがないことの検証
+        assert "business" not in content.lower() or "go_module" in content
+
+    def test_rust_template_no_reverse_dependency(self) -> None:
+        """tier-architecture.md: Rust Cargo.toml テンプレートに逆方向依存がない。"""
+        content = (TEMPLATES / "server" / "rust" / "Cargo.toml.tera").read_text(encoding="utf-8")
+        # テンプレートの依存セクションに逆方向参照がないことを確認
+        assert "{{ rust_crate }}" in content
+
+    def test_generate_tier_aware_path(self) -> None:
+        """tier-architecture.md: generate.rs が Tier を考慮したパス生成を行う。"""
+        content = (CLI_SRC / "commands" / "generate.rs").read_text(encoding="utf-8")
+        # Tier に応じたディレクトリ構造を生成する
+        assert "Tier::System" in content
+        assert "Tier::Business" in content
+        assert "Tier::Service" in content
+
+
+class TestSameTierCommunicationRules:
+    """tier-architecture.md: 同階層間通信ルールテスト。
+
+    Istio AuthorizationPolicy / NetworkPolicy で同階層間の通信ルールが
+    ドキュメント通りに設定されているか検証する。
+    """
+
+    def test_authorization_policy_exists(self) -> None:
+        """tier-architecture.md: Istio AuthorizationPolicy が定義されている。"""
+        assert (ROOT / "infra" / "istio" / "authorizationpolicy.yaml").exists()
+
+    def test_deny_bff_to_bff_policy(self) -> None:
+        """tier-architecture.md: BFF 間通信禁止ポリシーが存在する。"""
+        import yaml
+        path = ROOT / "infra" / "istio" / "authorizationpolicy.yaml"
+        content = path.read_text(encoding="utf-8")
+        docs = [d for d in yaml.safe_load_all(content) if d]
+        deny_policies = [d for d in docs if d["spec"]["action"] == "DENY"]
+        assert len(deny_policies) >= 1
+        assert any(d["metadata"]["name"] == "deny-bff-to-bff" for d in deny_policies)
+
+    def test_system_tier_allow_from_lower(self) -> None:
+        """tier-architecture.md: system は business, service からアクセス可。"""
+        import yaml
+        path = ROOT / "infra" / "istio" / "authorizationpolicy.yaml"
+        content = path.read_text(encoding="utf-8")
+        docs = [d for d in yaml.safe_load_all(content) if d]
+        system_allow = [
+            d for d in docs
+            if d["metadata"]["namespace"] == "k1s0-system"
+            and d["spec"]["action"] == "ALLOW"
+        ]
+        assert len(system_allow) >= 1
+
+
+class TestDatabaseAccessRestriction:
+    """tier-architecture.md: DBアクセス制限テスト。
+
+    各階層のデータベースはその階層の server からのみアクセスする。
+    """
+
+    def test_db_access_documented_in_tier_arch(self) -> None:
+        """tier-architecture.md: DB アクセス制限がドキュメントに記載されている。"""
+        content = (ROOT / "docs" / "tier-architecture.md").read_text(encoding="utf-8")
+        assert "その階層の server からのみアクセス" in content
+
+    def test_go_db_template_is_server_only(self) -> None:
+        """tier-architecture.md: DB テンプレート (persistence) はサーバーテンプレート内にのみ存在する。"""
+        # サーバーテンプレートに persistence がある
+        assert (TEMPLATES / "server" / "go" / "internal" / "infra" / "persistence" / "db.go.tera").exists()
+        # クライアントテンプレートには persistence がない
+        assert not (TEMPLATES / "client" / "react" / "persistence").exists()
+        assert not (TEMPLATES / "client" / "flutter" / "persistence").exists()
+
+    def test_rust_db_template_is_server_only(self) -> None:
+        """tier-architecture.md: Rust DB テンプレート (persistence) はサーバーテンプレート内にのみ存在する。"""
+        assert (TEMPLATES / "server" / "rust" / "src" / "infra" / "persistence.rs.tera").exists()
+
+
+class TestTierDiagramSVGs:
+    """tier-architecture.md: docs/diagrams/ 内 SVG ファイルの存在テスト。"""
+
+    @pytest.mark.parametrize(
+        "svg_file",
+        [
+            "docs/diagrams/tier-overview.svg",
+            "docs/diagrams/server-dependency.svg",
+            "docs/diagrams/client-dependency.svg",
+        ],
+    )
+    def test_diagram_svg_exists(self, svg_file: str) -> None:
+        """tier-architecture.md: 参照されている SVG ダイアグラムが存在する。"""
+        assert (ROOT / svg_file).exists(), f"{svg_file} が存在しません"
+
+
+# ============================================================================
+# ディレクトリ構成図.md ギャップ補完テスト
+# ============================================================================
+
+
+class TestDocsTsToTypescriptConsistency:
+    """ディレクトリ構成図.md: ts/ → typescript/ の一致検証。
+
+    ドキュメント内の library パスが実装 (CLI/templates/library/typescript) と一致するか。
+    """
+
+    def test_doc_uses_typescript_not_ts(self) -> None:
+        """ディレクトリ構成図.md: ドキュメント内で typescript/ と記載されている。"""
+        content = (ROOT / "docs" / "ディレクトリ構成図.md").read_text(encoding="utf-8")
+        # CLI セクション内で typescript/ が使われている（ts/ は使われていない）
+        # 注: CLI テンプレートディレクトリパスの記載箇所
+        assert "├── typescript/" in content or "typescript/" in content
+
+    def test_template_dir_is_typescript(self) -> None:
+        """ディレクトリ構成図.md: 実装側が CLI/templates/library/typescript/ である。"""
+        assert (ROOT / "CLI" / "templates" / "library" / "typescript").exists()
+
+
+class TestServerInternalStructure:
+    """ディレクトリ構成図.md: 生成後サーバー内部構成（クリーンアーキテクチャ）検証テスト。"""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "server/go/cmd/main.go.tera",
+            "server/go/internal/domain/model/entity.go.tera",
+            "server/go/internal/domain/repository/repository.go.tera",
+            "server/go/internal/usecase/usecase.go.tera",
+            "server/go/internal/adapter/handler/rest_handler.go.tera",
+            "server/go/internal/infra/persistence/db.go.tera",
+            "server/go/internal/infra/messaging/kafka.go.tera",
+            "server/go/internal/infra/config/config.go.tera",
+            "server/go/config/config.yaml.tera",
+            "server/go/Dockerfile.tera",
+            "server/go/go.mod.tera",
+        ],
+    )
+    def test_go_server_clean_architecture(self, path: str) -> None:
+        """ディレクトリ構成図.md: Go サーバーがクリーンアーキテクチャ構成を持つ。"""
+        assert (TEMPLATES / path).exists(), f"CLI/templates/{path} が存在しません"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "server/rust/src/main.rs.tera",
+            "server/rust/src/domain/model.rs.tera",
+            "server/rust/src/domain/repository.rs.tera",
+            "server/rust/src/usecase/service.rs.tera",
+            "server/rust/src/adapter/handler/rest.rs.tera",
+            "server/rust/src/infra/persistence.rs.tera",
+            "server/rust/src/infra/messaging.rs.tera",
+            "server/rust/src/infra/config.rs.tera",
+            "server/rust/config/config.yaml.tera",
+            "server/rust/Dockerfile.tera",
+            "server/rust/Cargo.toml.tera",
+        ],
+    )
+    def test_rust_server_clean_architecture(self, path: str) -> None:
+        """ディレクトリ構成図.md: Rust サーバーがクリーンアーキテクチャ構成を持つ。"""
+        assert (TEMPLATES / path).exists(), f"CLI/templates/{path} が存在しません"
+
+
+class TestClientInternalStructure:
+    """ディレクトリ構成図.md: 生成後クライアント内部構成検証テスト。"""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "client/react/src/app/App.tsx.tera",
+            "client/react/src/lib/api-client.ts.tera",
+            "client/react/src/lib/query-client.ts.tera",
+            "client/react/package.json.tera",
+            "client/react/Dockerfile.tera",
+        ],
+    )
+    def test_react_client_structure(self, path: str) -> None:
+        """ディレクトリ構成図.md: React クライアントの内部構成が仕様通り。"""
+        assert (TEMPLATES / path).exists(), f"CLI/templates/{path} が存在しません"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "client/flutter/lib/main.dart.tera",
+            "client/flutter/lib/app/router.dart.tera",
+            "client/flutter/lib/utils/dio_client.dart.tera",
+            "client/flutter/pubspec.yaml.tera",
+            "client/flutter/Dockerfile.tera",
+        ],
+    )
+    def test_flutter_client_structure(self, path: str) -> None:
+        """ディレクトリ構成図.md: Flutter クライアントの内部構成が仕様通り。"""
+        assert (TEMPLATES / path).exists(), f"CLI/templates/{path} が存在しません"
+
+
+class TestLibraryInternalStructure:
+    """ディレクトリ構成図.md: 生成後ライブラリ内部構成検証テスト。"""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "library/go/go.mod.tera",
+            "library/go/{name}.go.tera",
+            "library/go/internal/internal.go.tera",
+            "library/rust/Cargo.toml.tera",
+            "library/rust/src/lib.rs.tera",
+            "library/typescript/package.json.tera",
+            "library/typescript/tsconfig.json.tera",
+            "library/typescript/src/index.ts.tera",
+            "library/dart/pubspec.yaml.tera",
+            "library/dart/lib/{name}.dart.tera",
+        ],
+    )
+    def test_library_structure(self, path: str) -> None:
+        """ディレクトリ構成図.md: ライブラリテンプレートの内部構成が仕様通り。"""
+        assert (TEMPLATES / path).exists(), f"CLI/templates/{path} が存在しません"
+
+
+class TestDatabaseStructure:
+    """ディレクトリ構成図.md: 生成後 DB 構成 (migrations/, seeds/, schema/) 検証テスト。"""
+
+    def test_database_template_exists(self) -> None:
+        """ディレクトリ構成図.md: database テンプレートが存在する。"""
+        assert (TEMPLATES / "database").exists()
+
+    @pytest.mark.parametrize(
+        "rdbms",
+        ["postgresql", "mysql", "sqlite"],
+    )
+    def test_migration_up_template(self, rdbms: str) -> None:
+        """ディレクトリ構成図.md: migrations up SQL テンプレートが存在する。"""
+        assert (TEMPLATES / "database" / rdbms / "001_init.up.sql.tera").exists()
+
+    @pytest.mark.parametrize(
+        "rdbms",
+        ["postgresql", "mysql", "sqlite"],
+    )
+    def test_migration_down_template(self, rdbms: str) -> None:
+        """ディレクトリ構成図.md: migrations down SQL テンプレートが存在する。"""
+        assert (TEMPLATES / "database" / rdbms / "001_init.down.sql.tera").exists()
+
+
+class TestProtoEventDirectories:
+    """ディレクトリ構成図.md: api/proto イベントディレクトリ存在テスト。"""
+
+    @pytest.mark.parametrize(
+        "event_dir",
+        [
+            "api/proto/k1s0/event/system",
+            "api/proto/k1s0/event/business",
+            "api/proto/k1s0/event/service",
+        ],
+    )
+    def test_event_directory_exists(self, event_dir: str) -> None:
+        """ディレクトリ構成図.md: イベントディレクトリが存在する。"""
+        assert (ROOT / event_dir).exists(), f"{event_dir} が存在しません"
+
+
+class TestTestCodeSeparation:
+    """ディレクトリ構成図.md: テストコード分離規約テスト。
+
+    テストコードは tests/（Flutter/Dart は test/）ディレクトリに分離する。
+    ただし Go はユニットテスト (*_test.go) をソースと同一パッケージに、
+    Rust はユニットテスト (#[cfg(test)]) をソースと同一ファイルに配置する。
+    """
+
+    def test_go_server_test_files_colocated(self) -> None:
+        """ディレクトリ構成図.md: Go ユニットテストはソースと同一パッケージに配置。"""
+        # usecase_test.go がソースと同じディレクトリにある
+        assert (TEMPLATES / "server" / "go" / "internal" / "usecase" / "usecase_test.go.tera").exists()
+        assert (TEMPLATES / "server" / "go" / "internal" / "adapter" / "handler" / "handler_test.go.tera").exists()
+
+    def test_rust_server_integration_tests_separated(self) -> None:
+        """ディレクトリ構成図.md: Rust 統合テストは tests/ に分離。"""
+        assert (TEMPLATES / "server" / "rust" / "tests" / "integration_test.rs.tera").exists()
+
+    def test_react_client_tests_separated(self) -> None:
+        """ディレクトリ構成図.md: React テストコードは tests/ に分離。"""
+        assert (TEMPLATES / "client" / "react" / "tests" / "App.test.tsx.tera").exists()
+
+    def test_flutter_client_tests_separated(self) -> None:
+        """ディレクトリ構成図.md: Flutter テストコードは test/ に分離。"""
+        assert (TEMPLATES / "client" / "flutter" / "test" / "widget_test.dart.tera").exists()
+
+    def test_go_library_test_colocated(self) -> None:
+        """ディレクトリ構成図.md: Go ライブラリのユニットテストはソースと同一パッケージに配置。"""
+        assert (TEMPLATES / "library" / "go" / "{name}_test.go.tera").exists()
+
+    def test_go_library_integration_test_separated(self) -> None:
+        """ディレクトリ構成図.md: Go ライブラリの統合テストは tests/ に分離。"""
+        assert (TEMPLATES / "library" / "go" / "tests" / "integration_test.go.tera").exists()
+
+    def test_rust_library_integration_test_separated(self) -> None:
+        """ディレクトリ構成図.md: Rust ライブラリの統合テストは tests/ に分離。"""
+        assert (TEMPLATES / "library" / "rust" / "tests" / "integration_test.rs.tera").exists()

--- a/e2e/tests/docs_compliance/test_kubernetes.py
+++ b/e2e/tests/docs_compliance/test_kubernetes.py
@@ -17,12 +17,87 @@ class TestKubernetesNamespaces:
     @pytest.mark.parametrize(
         "namespace_file",
         [
+            "k1s0-system.yaml",
+            "k1s0-business.yaml",
+            "k1s0-service.yaml",
             "observability.yaml",
+            "messaging.yaml",
+            "ingress.yaml",
+            "service-mesh.yaml",
+            "cert-manager.yaml",
+            "harbor.yaml",
         ],
     )
     def test_namespace_file_exists(self, namespace_file: str) -> None:
         path = K8S / "namespaces" / namespace_file
         assert path.exists(), f"namespaces/{namespace_file} が存在しません"
+
+
+class TestKubernetesResourceQuota:
+    """kubernetes設計.md: ResourceQuota 値の検証。"""
+
+    @pytest.mark.parametrize(
+        "ns_file,expected",
+        [
+            ("k1s0-system.yaml", {
+                "requests.cpu": "8",
+                "requests.memory": "16Gi",
+                "limits.cpu": "16",
+                "limits.memory": "32Gi",
+                "pods": "50",
+            }),
+            ("k1s0-business.yaml", {
+                "requests.cpu": "16",
+                "requests.memory": "32Gi",
+                "limits.cpu": "32",
+                "limits.memory": "64Gi",
+                "pods": "100",
+            }),
+            ("k1s0-service.yaml", {
+                "requests.cpu": "8",
+                "requests.memory": "16Gi",
+                "limits.cpu": "16",
+                "limits.memory": "32Gi",
+                "pods": "50",
+            }),
+        ],
+    )
+    def test_resource_quota_values(self, ns_file: str, expected: dict) -> None:
+        """kubernetes設計.md: ResourceQuota の数値が仕様通りであること。"""
+        path = K8S / "namespaces" / ns_file
+        docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        quotas = [d for d in docs if d and d.get("kind") == "ResourceQuota"]
+        assert len(quotas) > 0, f"{ns_file} に ResourceQuota が定義されていません"
+        hard = quotas[0]["spec"]["hard"]
+        for key, val in expected.items():
+            assert str(hard[key]) == val, f"{ns_file}: {key} が {val} ではなく {hard[key]}"
+
+
+class TestKubernetesLimitRange:
+    """kubernetes設計.md: LimitRange 設定の検証。"""
+
+    @pytest.mark.parametrize(
+        "ns_file",
+        ["k1s0-system.yaml", "k1s0-business.yaml", "k1s0-service.yaml"],
+    )
+    def test_limit_range_exists(self, ns_file: str) -> None:
+        """kubernetes設計.md: 各 Namespace に LimitRange が定義されていること。"""
+        path = K8S / "namespaces" / ns_file
+        docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        lr = [d for d in docs if d and d.get("kind") == "LimitRange"]
+        assert len(lr) > 0, f"{ns_file} に LimitRange が定義されていません"
+
+    def test_limit_range_defaults(self) -> None:
+        """kubernetes設計.md: LimitRange のデフォルト値が仕様通りであること。"""
+        path = K8S / "namespaces" / "k1s0-service.yaml"
+        docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        lr = [d for d in docs if d and d.get("kind") == "LimitRange"][0]
+        limits = lr["spec"]["limits"][0]
+        assert limits["default"]["cpu"] == "1"
+        assert limits["default"]["memory"] == "1Gi"
+        assert limits["defaultRequest"]["cpu"] == "250m"
+        assert limits["defaultRequest"]["memory"] == "256Mi"
+        assert limits["type"] == "Container"
 
 
 class TestKubernetesRBAC:
@@ -50,22 +125,211 @@ class TestKubernetesRBAC:
         ]
         assert role_name in role_names, f"ClusterRole '{role_name}' が定義されていません"
 
+    def _get_role(self, name: str) -> dict:
+        for doc in self.docs:
+            if doc and doc.get("kind") == "ClusterRole" and doc["metadata"]["name"] == name:
+                return doc
+        raise AssertionError(f"ClusterRole '{name}' が見つかりません")
+
+    def test_developer_rules(self) -> None:
+        """kubernetes設計.md: k1s0-developer の rules が仕様通りであること。"""
+        role = self._get_role("k1s0-developer")
+        rules = role["rules"]
+        # ルール1: core API pods, services, configmaps -> get, list, watch
+        core_rule = [r for r in rules if "" in r["apiGroups"]]
+        assert len(core_rule) > 0
+        assert set(core_rule[0]["resources"]) == {"pods", "services", "configmaps"}
+        assert set(core_rule[0]["verbs"]) == {"get", "list", "watch"}
+        # ルール2: apps API deployments -> get, list, watch
+        apps_rule = [r for r in rules if "apps" in r["apiGroups"]]
+        assert len(apps_rule) > 0
+        assert "deployments" in apps_rule[0]["resources"]
+        assert set(apps_rule[0]["verbs"]) == {"get", "list", "watch"}
+
+    def test_operator_rules(self) -> None:
+        """kubernetes設計.md: k1s0-operator の rules が仕様通りであること。"""
+        role = self._get_role("k1s0-operator")
+        rules = role["rules"]
+        core_rule = [r for r in rules if "" in r["apiGroups"]]
+        assert len(core_rule) > 0
+        assert "secrets" in core_rule[0]["resources"]
+        assert "create" in core_rule[0]["verbs"]
+        assert "delete" in core_rule[0]["verbs"]
+        apps_rule = [r for r in rules if "apps" in r["apiGroups"]]
+        assert len(apps_rule) > 0
+        assert "statefulsets" in apps_rule[0]["resources"]
+        assert "patch" in apps_rule[0]["verbs"]
+
+    def test_admin_rules(self) -> None:
+        """kubernetes設計.md: k1s0-admin はクラスタ全体の管理権限を持つこと。"""
+        role = self._get_role("k1s0-admin")
+        rules = role["rules"]
+        assert rules[0]["apiGroups"] == ["*"]
+        assert rules[0]["resources"] == ["*"]
+        assert rules[0]["verbs"] == ["*"]
+
+    def test_readonly_rules(self) -> None:
+        """kubernetes設計.md: readonly は全リソースの参照のみであること。"""
+        role = self._get_role("readonly")
+        rules = role["rules"]
+        assert rules[0]["apiGroups"] == ["*"]
+        assert rules[0]["resources"] == ["*"]
+        assert set(rules[0]["verbs"]) == {"get", "list", "watch"}
+
 
 class TestKubernetesIngress:
     """kubernetes設計.md: Ingress リソースの検証。"""
 
+    def setup_method(self) -> None:
+        path = K8S / "ingress" / "ingress.yaml"
+        assert path.exists(), "ingress/ingress.yaml が存在しません"
+        self.docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+
     def test_ingress_directory_exists(self) -> None:
-        assert (K8S / "ingress").exists() or (
-            ROOT / "infra" / "kubernetes"
-        ).exists(), "kubernetes/ingress が存在しません"
+        assert (K8S / "ingress").exists(), "kubernetes/ingress が存在しません"
+
+    def test_ingress_annotations(self) -> None:
+        """kubernetes設計.md: Ingress annotations が仕様通りであること。"""
+        ingress = [d for d in self.docs if d and d.get("kind") == "Ingress"][0]
+        annotations = ingress["metadata"]["annotations"]
+        assert annotations["nginx.ingress.kubernetes.io/ssl-redirect"] == "true"
+        assert annotations["cert-manager.io/cluster-issuer"] == "internal-ca"
+
+    def test_ingress_tls(self) -> None:
+        """kubernetes設計.md: Ingress TLS 設定が仕様通りであること。"""
+        ingress = [d for d in self.docs if d and d.get("kind") == "Ingress"][0]
+        tls = ingress["spec"]["tls"]
+        assert len(tls) > 0
+        assert "*.k1s0.internal.example.com" in tls[0]["hosts"]
+        assert tls[0]["secretName"] == "k1s0-tls"
+
+    def test_ingress_class_name(self) -> None:
+        """kubernetes設計.md: ingressClassName が nginx であること。"""
+        ingress = [d for d in self.docs if d and d.get("kind") == "Ingress"][0]
+        assert ingress["spec"]["ingressClassName"] == "nginx"
+
+
+class TestKubernetesStorageClass:
+    """kubernetes設計.md: StorageClass 用途テスト。"""
+
+    def setup_method(self) -> None:
+        path = ROOT / "infra" / "terraform" / "modules" / "kubernetes-storage" / "main.tf"
+        assert path.exists()
+        self.content = path.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "sc_name,usage",
+        [
+            ("ceph-block", "一般用途"),
+            ("ceph-filesystem", "共有ストレージ"),
+            ("ceph-block-fast", "データベース用"),
+        ],
+    )
+    def test_storage_class_defined(self, sc_name: str, usage: str) -> None:
+        """kubernetes設計.md: 3 種類の StorageClass が定義されていること。"""
+        assert sc_name in self.content, f"StorageClass '{sc_name}'({usage}) が定義されていません"
+
+
+class TestKubernetesLabels:
+    """kubernetes設計.md: ラベル規約テスト。"""
+
+    def setup_method(self) -> None:
+        helpers = ROOT / "infra" / "helm" / "charts" / "k1s0-common" / "templates" / "_helpers.tpl"
+        assert helpers.exists(), "_helpers.tpl が存在しません"
+        self.helpers_content = helpers.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "app.kubernetes.io/name",
+            "app.kubernetes.io/version",
+            "app.kubernetes.io/component",
+            "app.kubernetes.io/part-of",
+            "app.kubernetes.io/managed-by",
+            "tier",
+        ],
+    )
+    def test_label_in_helm_helpers(self, label: str) -> None:
+        """kubernetes設計.md: 6 標準ラベルが Helm テンプレートまたは設定ファイルで使用されていること。"""
+        if label == "tier":
+            # tier は values.yaml の labels セクションで動的に設定される
+            # _helpers.tpl では .Values.labels をイテレートして出力する
+            assert ".Values.labels" in self.helpers_content, (
+                "ラベル 'tier' の出力処理（.Values.labels のイテレーション）が _helpers.tpl に存在しません"
+            )
+        else:
+            assert label in self.helpers_content, f"ラベル '{label}' が _helpers.tpl に存在しません"
 
 
 class TestKubernetesNetworkPolicies:
     """kubernetes設計.md: NetworkPolicy が Terraform で定義されていることの検証。"""
 
-    def test_network_policy_in_terraform(self) -> None:
-        """kubernetes設計.md: NetworkPolicy は terraform kubernetes-base モジュールで管理。"""
+    def setup_method(self) -> None:
         tf_path = ROOT / "infra" / "terraform" / "modules" / "kubernetes-base" / "main.tf"
         assert tf_path.exists()
-        content = tf_path.read_text(encoding="utf-8")
-        assert "kubernetes_network_policy" in content
+        self.content = tf_path.read_text(encoding="utf-8")
+
+    def test_network_policy_in_terraform(self) -> None:
+        """kubernetes設計.md: NetworkPolicy は terraform kubernetes-base モジュールで管理。"""
+        assert "kubernetes_network_policy" in self.content
+
+    def test_network_policy_deny_cross_tier(self) -> None:
+        """kubernetes設計.md: deny-cross-tier ポリシーが定義されていること。"""
+        assert "deny-cross-tier" in self.content or "deny_cross_tier" in self.content
+
+    def test_network_policy_ingress_rules(self) -> None:
+        """kubernetes設計.md: ingress ルールが定義されていること。"""
+        assert "ingress" in self.content.lower()
+        assert "namespace_selector" in self.content
+
+
+class TestKubernetesHPABehavior:
+    """kubernetes設計.md: HPA behavior 設定テスト。"""
+
+    def test_hpa_template_exists(self) -> None:
+        """kubernetes設計.md: HPA テンプレートが存在すること。"""
+        path = ROOT / "infra" / "helm" / "charts" / "k1s0-common" / "templates" / "_hpa.tpl"
+        assert path.exists(), "_hpa.tpl が存在しません"
+
+
+class TestKubernetesEnvironmentHPA:
+    """kubernetes設計.md: 環境別 HPA 設定テスト。"""
+
+    def test_dev_hpa_disabled(self) -> None:
+        """kubernetes設計.md: dev では HPA 無効がデフォルト。"""
+        path = ROOT / "infra" / "helm" / "services" / "service" / "order" / "values-dev.yaml"
+        with open(path, encoding="utf-8") as f:
+            values = yaml.safe_load(f)
+        assert values["autoscaling"]["enabled"] is False
+
+    def test_staging_hpa_replicas(self) -> None:
+        """kubernetes設計.md: staging は minReplicas:2, maxReplicas:5。"""
+        path = ROOT / "infra" / "helm" / "services" / "service" / "order" / "values-staging.yaml"
+        with open(path, encoding="utf-8") as f:
+            values = yaml.safe_load(f)
+        assert values["autoscaling"]["minReplicas"] == 2
+        assert values["autoscaling"]["maxReplicas"] == 5
+
+    def test_prod_hpa_replicas(self) -> None:
+        """kubernetes設計.md: prod は minReplicas:3, maxReplicas:10。"""
+        path = ROOT / "infra" / "helm" / "services" / "service" / "order" / "values-prod.yaml"
+        with open(path, encoding="utf-8") as f:
+            values = yaml.safe_load(f)
+        assert values["autoscaling"]["minReplicas"] == 3
+        assert values["autoscaling"]["maxReplicas"] == 10
+
+
+class TestKubernetesPDB:
+    """kubernetes設計.md: PodDisruptionBudget テスト。"""
+
+    def test_pdb_min_available(self) -> None:
+        """kubernetes設計.md: PDB minAvailable が 1 であること。"""
+        path = ROOT / "infra" / "helm" / "services" / "service" / "order" / "values.yaml"
+        with open(path, encoding="utf-8") as f:
+            values = yaml.safe_load(f)
+        assert values["pdb"]["minAvailable"] == 1
+
+    def test_pdb_template_exists(self) -> None:
+        """kubernetes設計.md: PDB テンプレートが存在すること。"""
+        path = ROOT / "infra" / "helm" / "charts" / "k1s0-common" / "templates" / "_pdb.tpl"
+        assert path.exists(), "_pdb.tpl が存在しません"

--- a/e2e/tests/docs_compliance/test_template_cicd.py
+++ b/e2e/tests/docs_compliance/test_template_cicd.py
@@ -83,6 +83,9 @@ class TestCicdTemplateVariables:
             ("deploy.yaml.tera", "{{ service_name }}"),
             ("deploy.yaml.tera", "{{ module_path }}"),
             ("deploy.yaml.tera", "{{ docker_project }}"),
+            ("deploy.yaml.tera", "{{ docker_registry }}"),
+            ("deploy.yaml.tera", "{{ helm_path }}"),
+            ("deploy.yaml.tera", "{{ tier }}"),
         ],
     )
     def test_template_variable_used(self, template: str, variable: str) -> None:
@@ -107,6 +110,31 @@ class TestCicdSpecGenerationTarget:
     def test_deploy_server_only(self) -> None:
         assert "server" in self.content
         assert "Deploy" in self.content
+
+
+class TestCicdDirectoryStructure:
+    """仕様書に定義されたディレクトリ構造との一致検証。"""
+
+    def test_cicd_directory_is_flat(self) -> None:
+        """cicd/ 直下に ci.yaml.tera と deploy.yaml.tera がフラットに配置されている。"""
+        assert (CICD / "ci.yaml.tera").exists()
+        assert (CICD / "deploy.yaml.tera").exists()
+
+    def test_no_language_subdirectories(self) -> None:
+        """cicd/ 配下に言語別サブディレクトリが存在しない。"""
+        for item in CICD.iterdir():
+            assert item.is_file(), f"cicd/ 配下にディレクトリ '{item.name}' が存在します（フラット構造違反）"
+
+
+class TestCicdTemplateRawBlocks:
+    """テンプレートファイル内の {% raw %} ブロック検証。"""
+
+    @pytest.mark.parametrize("template", ["ci.yaml.tera", "deploy.yaml.tera"])
+    def test_template_has_raw_blocks(self, template: str) -> None:
+        path = CICD / template
+        content = path.read_text(encoding="utf-8")
+        assert "{% raw %}" in content, f"cicd/{template} に {{% raw %}} ブロックがありません"
+        assert "{% endraw %}" in content, f"cicd/{template} に {{% endraw %}} ブロックがありません"
 
 
 class TestCicdSpecLanguageVersions:

--- a/e2e/tests/docs_compliance/test_template_content_client.py
+++ b/e2e/tests/docs_compliance/test_template_content_client.py
@@ -404,3 +404,60 @@ class TestFlutterNginxConfContent:
     def test_listen_port(self) -> None:
         content = (FLUTTER / "nginx.conf.tera").read_text(encoding="utf-8")
         assert "listen 8080" in content
+
+
+class TestReactReadmeContent:
+    """テンプレート仕様-クライアント.md: React README.md.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (REACT / "README.md.tera").read_text(encoding="utf-8")
+
+    def test_service_name_variable(self) -> None:
+        assert "{{ service_name }}" in self.content
+
+    def test_npm_install_command(self) -> None:
+        assert "npm install" in self.content or "npm ci" in self.content
+
+    def test_dev_command(self) -> None:
+        assert "npm run dev" in self.content or "dev" in self.content
+
+
+class TestFlutterReadmeContent:
+    """テンプレート仕様-クライアント.md: Flutter README.md.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (FLUTTER / "README.md.tera").read_text(encoding="utf-8")
+
+    def test_service_name_variable(self) -> None:
+        assert "{{ service_name }}" in self.content or "{{ service_name_pascal }}" in self.content
+
+    def test_flutter_command(self) -> None:
+        assert "flutter" in self.content
+
+
+class TestReactTestFilesContent:
+    """テンプレート仕様-クライアント.md: React テストファイルの内容検証。"""
+
+    def test_app_test_exists(self) -> None:
+        assert (REACT / "tests" / "App.test.tsx.tera").exists()
+
+    def test_app_test_content(self) -> None:
+        content = (REACT / "tests" / "App.test.tsx.tera").read_text(encoding="utf-8")
+        assert "test" in content or "describe" in content or "expect" in content
+
+    def test_setup_ts_exists(self) -> None:
+        assert (REACT / "tests" / "testutil" / "setup.ts.tera").exists()
+
+    def test_msw_setup_exists(self) -> None:
+        assert (REACT / "tests" / "testutil" / "msw-setup.ts.tera").exists()
+
+
+class TestFlutterTestFilesContent:
+    """テンプレート仕様-クライアント.md: Flutter テストファイルの内容検証。"""
+
+    def test_widget_test_exists(self) -> None:
+        assert (FLUTTER / "test" / "widget_test.dart.tera").exists()
+
+    def test_widget_test_content(self) -> None:
+        content = (FLUTTER / "test" / "widget_test.dart.tera").read_text(encoding="utf-8")
+        assert "testWidgets" in content or "test" in content

--- a/e2e/tests/docs_compliance/test_template_content_server.py
+++ b/e2e/tests/docs_compliance/test_template_content_server.py
@@ -560,3 +560,319 @@ class TestGoProtoContent:
         assert "Get{{ service_name_pascal }}" in self.content
         assert "List{{ service_name_pascal }}" in self.content
         assert "Create{{ service_name_pascal }}" in self.content
+
+
+class TestGoOapiCodegenYamlContent:
+    """テンプレート仕様-サーバー.md: oapi-codegen.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_GO / "oapi-codegen.yaml.tera").read_text(encoding="utf-8")
+
+    def test_rest_conditional(self) -> None:
+        assert '{% if api_style == "rest" %}' in self.content
+
+    def test_package_name(self) -> None:
+        assert "package: openapi" in self.content
+
+    def test_gin_server_generation(self) -> None:
+        assert "gin-server: true" in self.content
+
+    def test_models_generation(self) -> None:
+        assert "models: true" in self.content
+
+    def test_embedded_spec(self) -> None:
+        assert "embedded-spec: true" in self.content
+
+    def test_output_path(self) -> None:
+        assert "internal/adapter/handler/openapi_gen.go" in self.content
+
+
+class TestGoGqlgenYmlContent:
+    """テンプレート仕様-サーバー.md: gqlgen.yml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_GO / "gqlgen.yml.tera").read_text(encoding="utf-8")
+
+    def test_graphql_conditional(self) -> None:
+        assert '{% if api_style == "graphql" %}' in self.content
+
+    def test_schema_path(self) -> None:
+        assert "api/graphql/*.graphql" in self.content
+
+    def test_exec_package(self) -> None:
+        assert "package: graphql" in self.content
+
+    def test_resolver_layout(self) -> None:
+        assert "layout: follow-schema" in self.content
+
+
+class TestGoSchemaGraphqlContent:
+    """テンプレート仕様-サーバー.md: schema.graphql.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_GO / "api" / "graphql" / "schema.graphql.tera").read_text(encoding="utf-8")
+
+    def test_graphql_conditional(self) -> None:
+        assert '{% if api_style == "graphql" %}' in self.content
+
+    def test_query_type(self) -> None:
+        assert "type Query" in self.content
+
+    def test_entity_type(self) -> None:
+        assert "{{ service_name_pascal }}" in self.content
+
+    def test_create_input(self) -> None:
+        assert "Create{{ service_name_pascal }}Input" in self.content
+
+
+class TestGoBufYamlContent:
+    """テンプレート仕様-サーバー.md: buf.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_GO / "buf.yaml.tera").read_text(encoding="utf-8")
+
+    def test_grpc_conditional(self) -> None:
+        assert '{% if api_style == "grpc" %}' in self.content
+
+    def test_version(self) -> None:
+        assert "version: v2" in self.content
+
+    def test_lint_standard(self) -> None:
+        assert "STANDARD" in self.content
+
+    def test_breaking_file(self) -> None:
+        assert "FILE" in self.content
+
+
+class TestGoBufGenYamlContent:
+    """テンプレート仕様-サーバー.md: buf.gen.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_GO / "buf.gen.yaml.tera").read_text(encoding="utf-8")
+
+    def test_grpc_conditional(self) -> None:
+        assert '{% if api_style == "grpc" %}' in self.content
+
+    def test_protobuf_plugin(self) -> None:
+        assert "buf.build/protocolbuffers/go" in self.content
+
+    def test_grpc_plugin(self) -> None:
+        assert "buf.build/grpc/go" in self.content
+
+    def test_output_path(self) -> None:
+        assert "api/proto/gen" in self.content
+
+
+class TestGoReadmeContent:
+    """テンプレート仕様-サーバー.md: Go README.md.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_GO / "README.md.tera").read_text(encoding="utf-8")
+
+    def test_service_name_variable(self) -> None:
+        assert "{{ service_name }}" in self.content
+
+    def test_setup_section(self) -> None:
+        assert "go mod tidy" in self.content
+
+    def test_run_command(self) -> None:
+        assert "go run" in self.content
+
+    def test_test_command(self) -> None:
+        assert "go test" in self.content
+
+    def test_directory_structure(self) -> None:
+        assert "cmd/" in self.content
+        assert "internal/" in self.content
+        assert "config/" in self.content
+
+
+class TestRustReadmeContent:
+    """テンプレート仕様-サーバー.md: Rust README.md.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_RUST / "README.md.tera").read_text(encoding="utf-8")
+
+    def test_service_name_variable(self) -> None:
+        assert "{{ service_name }}" in self.content
+
+    def test_setup_section(self) -> None:
+        assert "cargo build" in self.content
+
+    def test_run_command(self) -> None:
+        assert "cargo run" in self.content
+
+    def test_test_command(self) -> None:
+        assert "cargo test" in self.content
+
+    def test_directory_structure(self) -> None:
+        assert "src/" in self.content
+        assert "Cargo.toml" in self.content
+
+
+class TestRustBuildRsContent:
+    """テンプレート仕様-サーバー.md: build.rs.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_RUST / "build.rs.tera").read_text(encoding="utf-8")
+
+    def test_grpc_conditional(self) -> None:
+        assert '{% if api_style == "grpc" %}' in self.content
+
+    def test_tonic_build(self) -> None:
+        assert "tonic_build" in self.content
+
+    def test_build_server(self) -> None:
+        assert "build_server(true)" in self.content
+
+    def test_compile_protos(self) -> None:
+        assert "compile_protos" in self.content
+
+
+class TestRustBufYamlContent:
+    """テンプレート仕様-サーバー.md: Rust buf.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_RUST / "buf.yaml.tera").read_text(encoding="utf-8")
+
+    def test_grpc_conditional(self) -> None:
+        assert '{% if api_style == "grpc" %}' in self.content
+
+    def test_version(self) -> None:
+        assert "version: v2" in self.content
+
+    def test_lint_standard(self) -> None:
+        assert "STANDARD" in self.content
+
+
+class TestGoUsecaseTestContent:
+    """テンプレート仕様-サーバー.md: usecase_test.go.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (
+            SERVER_GO / "internal" / "usecase" / "usecase_test.go.tera"
+        ).read_text(encoding="utf-8")
+
+    def test_package_usecase(self) -> None:
+        assert "package usecase" in self.content
+
+    def test_testify_imports(self) -> None:
+        assert "testify/assert" in self.content
+        assert "testify/require" in self.content
+
+    def test_gomock_conditional(self) -> None:
+        assert "{% if has_database %}" in self.content
+        assert "gomock" in self.content
+
+    def test_test_functions(self) -> None:
+        assert "TestGetByID" in self.content
+        assert "TestGetAll" in self.content
+        assert "TestCreate" in self.content
+
+
+class TestGoHandlerTestContent:
+    """テンプレート仕様-サーバー.md: handler_test.go.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (
+            SERVER_GO / "internal" / "adapter" / "handler" / "handler_test.go.tera"
+        ).read_text(encoding="utf-8")
+
+    def test_rest_test(self) -> None:
+        assert '{% if api_style == "rest" %}' in self.content
+        assert "httptest" in self.content
+        assert "TestList" in self.content
+
+    def test_grpc_test(self) -> None:
+        assert '{% if api_style == "grpc" %}' in self.content
+        assert "bufconn" in self.content
+
+    def test_graphql_test(self) -> None:
+        assert '{% if api_style == "graphql" %}' in self.content
+        assert "NewResolver" in self.content
+
+
+class TestGoRepositoryTestContent:
+    """テンプレート仕様-サーバー.md: repository_test.go.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (
+            SERVER_GO / "internal" / "infra" / "persistence" / "repository_test.go.tera"
+        ).read_text(encoding="utf-8")
+
+    def test_database_conditional(self) -> None:
+        assert "{% if has_database %}" in self.content
+
+    def test_testcontainers(self) -> None:
+        assert "testcontainers" in self.content
+
+    def test_integration_skip(self) -> None:
+        assert "testing.Short()" in self.content
+
+    def test_postgresql_container(self) -> None:
+        assert "postgres" in self.content
+
+    def test_mysql_container(self) -> None:
+        assert "mysql" in self.content
+
+
+class TestRustIntegrationTestContent:
+    """テンプレート仕様-サーバー.md: Rust tests/integration_test.rs.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (SERVER_RUST / "tests" / "integration_test.rs.tera").read_text(encoding="utf-8")
+
+    def test_rest_test(self) -> None:
+        assert '{% if api_style == "rest" %}' in self.content
+        assert "StatusCode::OK" in self.content
+
+    def test_grpc_test(self) -> None:
+        assert '{% if api_style == "grpc" %}' in self.content
+
+    def test_graphql_test(self) -> None:
+        assert '{% if api_style == "graphql" %}' in self.content
+        assert "build_schema" in self.content
+
+
+# ============================================================================
+# コンセプト.md ギャップ補完テスト
+# ============================================================================
+
+
+class TestOpenTelemetryInServerTemplates:
+    """コンセプト.md: 可観測性のゼロコンフィグ — OpenTelemetry 初期化コードがサーバーテンプレートに含まれるか。"""
+
+    def test_go_main_otel_import(self) -> None:
+        """コンセプト.md: Go テンプレートに OpenTelemetry のインポートが含まれる。"""
+        content = (SERVER_GO / "cmd" / "main.go.tera").read_text(encoding="utf-8")
+        assert "opentelemetry" in content.lower() or "otelgin" in content
+
+    def test_go_main_otel_middleware(self) -> None:
+        """コンセプト.md: Go テンプレートに otelgin ミドルウェアが設定されている。"""
+        content = (SERVER_GO / "cmd" / "main.go.tera").read_text(encoding="utf-8")
+        assert "otelgin.Middleware" in content
+
+    def test_go_mod_otel_dependency(self) -> None:
+        """コンセプト.md: Go go.mod に OpenTelemetry 依存が含まれる。"""
+        content = (SERVER_GO / "go.mod.tera").read_text(encoding="utf-8")
+        assert "go.opentelemetry.io/otel" in content
+
+    def test_rust_cargo_otel_dependency(self) -> None:
+        """コンセプト.md: Rust Cargo.toml に OpenTelemetry 依存が含まれる。"""
+        content = (SERVER_RUST / "Cargo.toml.tera").read_text(encoding="utf-8")
+        assert "opentelemetry" in content
+
+    def test_rust_main_tracing_subscriber(self) -> None:
+        """コンセプト.md: Rust テンプレートに tracing_subscriber が設定されている。"""
+        content = (SERVER_RUST / "src" / "main.rs.tera").read_text(encoding="utf-8")
+        assert "tracing_subscriber" in content
+
+    def test_go_config_observability_section(self) -> None:
+        """コンセプト.md: Go config.yaml に observability セクションが含まれる。"""
+        content = (SERVER_GO / "config" / "config.yaml.tera").read_text(encoding="utf-8")
+        assert "observability:" in content
+
+    def test_rust_config_observability_section(self) -> None:
+        """コンセプト.md: Rust config.yaml に observability セクションが含まれる。"""
+        content = (SERVER_RUST / "config" / "config.yaml.tera").read_text(encoding="utf-8")
+        assert "observability:" in content

--- a/e2e/tests/docs_compliance/test_template_helm.py
+++ b/e2e/tests/docs_compliance/test_template_helm.py
@@ -117,3 +117,201 @@ class TestHelmTemplateVariables:
         assert include_call in content, (
             f"helm/{template} に Library Chart 呼び出し '{include_call}' が含まれていません"
         )
+
+
+class TestHelmValuesStagingContent:
+    """テンプレート仕様-Helm.md: values-staging.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "values-staging.yaml.tera").read_text(encoding="utf-8")
+
+    def test_replica_count(self) -> None:
+        assert "replicaCount: 2" in self.content
+
+    def test_autoscaling_enabled(self) -> None:
+        assert "enabled: true" in self.content
+
+    def test_min_replicas(self) -> None:
+        assert "minReplicas: 2" in self.content
+
+    def test_environment_staging(self) -> None:
+        assert "environment: staging" in self.content
+
+    def test_database_conditional(self) -> None:
+        assert "has_database" in self.content
+
+    def test_ssl_mode_require(self) -> None:
+        """テンプレート仕様-Helm.md: ステージングはssl_mode: require。"""
+        assert "ssl_mode: require" in self.content
+
+    def test_trace_sample_rate(self) -> None:
+        assert "sample_rate: 0.5" in self.content
+
+
+class TestHelmValuesContent:
+    """テンプレート仕様-Helm.md: values.yaml.tera の主要フィールド検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "values.yaml.tera").read_text(encoding="utf-8")
+
+    def test_image_section(self) -> None:
+        assert "image:" in self.content
+        assert "{{ docker_registry }}" in self.content
+        assert "{{ docker_project }}" in self.content
+
+    def test_replica_count(self) -> None:
+        assert "replicaCount:" in self.content
+
+    def test_resources(self) -> None:
+        assert "resources:" in self.content
+        assert "requests:" in self.content
+        assert "limits:" in self.content
+
+    def test_probes(self) -> None:
+        assert "/healthz" in self.content
+        assert "/readyz" in self.content
+
+    def test_security_context(self) -> None:
+        assert "runAsNonRoot: true" in self.content
+        assert "readOnlyRootFilesystem: true" in self.content
+
+    def test_vault_section(self) -> None:
+        assert "vault:" in self.content
+        assert "{{ tier }}" in self.content
+
+    def test_grpc_port_conditional(self) -> None:
+        assert "grpcPort:" in self.content
+
+    def test_kafka_section(self) -> None:
+        assert "kafka:" in self.content
+        assert "{{ has_kafka }}" in self.content
+
+    def test_redis_section(self) -> None:
+        assert "redis:" in self.content
+        assert "{{ has_redis }}" in self.content
+
+
+class TestHelmChartYamlContent:
+    """テンプレート仕様-Helm.md: Chart.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "Chart.yaml.tera").read_text(encoding="utf-8")
+
+    def test_api_version(self) -> None:
+        assert "apiVersion: v2" in self.content
+
+    def test_service_name(self) -> None:
+        assert "{{ service_name }}" in self.content
+
+    def test_description(self) -> None:
+        assert "{{ service_name_pascal }}" in self.content
+
+    def test_type_application(self) -> None:
+        assert "type: application" in self.content
+
+    def test_k1s0_common_dependency(self) -> None:
+        assert "k1s0-common" in self.content
+
+    def test_business_tier_path(self) -> None:
+        """テンプレート仕様-Helm.md: business tier のLibrary Chart相対パス。"""
+        assert "../../../../charts/k1s0-common" in self.content
+
+    def test_default_tier_path(self) -> None:
+        """テンプレート仕様-Helm.md: system/service tier のLibrary Chart相対パス。"""
+        assert "../../../charts/k1s0-common" in self.content
+
+
+class TestHelmTemplateConfigmapContent:
+    """テンプレート仕様-Helm.md: configmap.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "templates" / "configmap.yaml.tera").read_text(encoding="utf-8")
+
+    def test_library_chart_call(self) -> None:
+        assert "k1s0-common.configmap" in self.content
+
+    def test_raw_endraw(self) -> None:
+        """テンプレート仕様-Helm.md: raw/endraw でHelm構文を保護。"""
+        assert "{% raw %}" in self.content
+        assert "{% endraw %}" in self.content
+
+
+class TestHelmTemplateHpaContent:
+    """テンプレート仕様-Helm.md: hpa.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "templates" / "hpa.yaml.tera").read_text(encoding="utf-8")
+
+    def test_library_chart_call(self) -> None:
+        assert "k1s0-common.hpa" in self.content
+
+    def test_raw_endraw(self) -> None:
+        assert "{% raw %}" in self.content
+        assert "{% endraw %}" in self.content
+
+
+class TestHelmTemplatePdbContent:
+    """テンプレート仕様-Helm.md: pdb.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "templates" / "pdb.yaml.tera").read_text(encoding="utf-8")
+
+    def test_library_chart_call(self) -> None:
+        assert "k1s0-common.pdb" in self.content
+
+    def test_raw_endraw(self) -> None:
+        assert "{% raw %}" in self.content
+        assert "{% endraw %}" in self.content
+
+
+class TestHelmValuesProdContent:
+    """テンプレート仕様-Helm.md: values-prod.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "values-prod.yaml.tera").read_text(encoding="utf-8")
+
+    def test_replica_count(self) -> None:
+        assert "replicaCount: 3" in self.content
+
+    def test_autoscaling_max_replicas(self) -> None:
+        assert "maxReplicas: 10" in self.content
+
+    def test_pod_anti_affinity(self) -> None:
+        assert "podAntiAffinity" in self.content
+
+    def test_raw_endraw_syntax(self) -> None:
+        """テンプレート仕様-Helm.md: raw/endraw で Go テンプレート構文を保護。"""
+        assert "{% raw %}" in self.content
+        assert "{% endraw %}" in self.content
+
+    def test_environment_prod(self) -> None:
+        assert "environment: prod" in self.content
+
+    def test_ssl_mode_verify_full(self) -> None:
+        """テンプレート仕様-Helm.md: 本番はssl_mode: verify-full。"""
+        assert "ssl_mode: verify-full" in self.content
+
+
+class TestHelmValuesDevContent:
+    """テンプレート仕様-Helm.md: values-dev.yaml.tera の内容検証。"""
+
+    def setup_method(self) -> None:
+        self.content = (HELM / "values-dev.yaml.tera").read_text(encoding="utf-8")
+
+    def test_replica_count(self) -> None:
+        assert "replicaCount: 1" in self.content
+
+    def test_autoscaling_disabled(self) -> None:
+        assert "enabled: false" in self.content
+
+    def test_pdb_disabled(self) -> None:
+        assert "pdb:" in self.content
+
+    def test_vault_disabled(self) -> None:
+        assert "vault:" in self.content
+
+    def test_environment_dev(self) -> None:
+        assert "environment: dev" in self.content
+
+    def test_log_level_debug(self) -> None:
+        assert "level: debug" in self.content

--- a/infra/messaging/saga/workflows/order-fulfillment.yaml
+++ b/infra/messaging/saga/workflows/order-fulfillment.yaml
@@ -1,0 +1,29 @@
+# workflows/order-fulfillment.yaml
+name: order-fulfillment
+steps:
+  - name: reserve-inventory
+    service: inventory-server
+    method: InventoryService.Reserve
+    compensate: InventoryService.Release
+    timeout: 30s
+    retry:
+      max_attempts: 3
+      backoff: exponential
+
+  - name: process-payment
+    service: payment-server
+    method: PaymentService.Charge
+    compensate: PaymentService.Refund
+    timeout: 30s
+    retry:
+      max_attempts: 3
+      backoff: exponential
+
+  - name: confirm-order
+    service: order-server
+    method: OrderService.Confirm
+    compensate: OrderService.Cancel
+    timeout: 30s
+    retry:
+      max_attempts: 3
+      backoff: exponential

--- a/infra/observability/grafana/dashboards/overview.json
+++ b/infra/observability/grafana/dashboards/overview.json
@@ -1,0 +1,133 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "title": "Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(http_requests_total[5m])",
+          "legendFormat": "{{namespace}}/{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      }
+    },
+    {
+      "title": "Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "rate(http_requests_total{status=~\"5..\"}[5m]) / rate(http_requests_total[5m])",
+          "legendFormat": "{{namespace}}/{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      }
+    },
+    {
+      "title": "P50 Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "{{namespace}}/{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "title": "P95 Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "{{namespace}}/{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "title": "P99 Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "{{namespace}}/{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "title": "Pod CPU Usage",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{namespace=~\"k1s0-.*\"}[5m])",
+          "legendFormat": "{{namespace}}/{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Pod Memory Usage",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "expr": "container_memory_working_set_bytes{namespace=~\"k1s0-.*\"} / container_spec_memory_limit_bytes",
+          "legendFormat": "{{namespace}}/{{pod}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["k1s0", "overview"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "title": "k1s0 Overview",
+  "uid": "k1s0-overview"
+}

--- a/infra/observability/grafana/dashboards/slo.json
+++ b/infra/observability/grafana/dashboards/slo.json
@@ -1,0 +1,77 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "title": "Availability",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status!~\"5..\"}[30d])) / sum(rate(http_requests_total[30d]))",
+          "legendFormat": "availability",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.999 },
+              { "color": "green", "value": 0.9995 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "Error Budget Remaining",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "targets": [
+        {
+          "expr": "slo:error_budget:remaining",
+          "legendFormat": "{{namespace}}/{{service}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      }
+    },
+    {
+      "title": "Burn Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "expr": "1 - (sum(rate(http_requests_total{status!~\"5..\"}[1h])) / sum(rate(http_requests_total[1h])))",
+          "legendFormat": "burn_rate",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["k1s0", "slo"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "title": "k1s0 SLO",
+  "uid": "k1s0-slo"
+}


### PR DESCRIPTION
- e2e/tests/docs_compliance/test_service_mesh.py:
  - VirtualServiceの具体値を検証するテストを追加。
  - Circuit Breaker Tierのデフォルト値を検証するテストを追加。

- e2e/tests/docs_compliance/test_template_cicd.py:
  - CI/CDテンプレート変数の検証を強化。
  - CI/CDディレクトリ構造の検証テストを追加。
  - テンプレート内のrawブロック検証を追加。

- e2e/tests/docs_compliance/test_template_content_client.py:
  - ReactおよびFlutterのREADME.mdテンプレート内容を検証するテストを追加。
  - ReactおよびFlutterのテストファイルの存在と内容を検証するテストを追加。

- e2e/tests/docs_compliance/test_template_content_server.py:
  - Go関連のテンプレート内容検証を追加。
  - OpenTelemetryの初期化コードが含まれているかを検証するテストを追加。

- e2e/tests/docs_compliance/test_template_helm.py:
  - Helmテンプレートのvaluesファイルの内容を検証するテストを追加。
  - Helmテンプレートのconfigmap、hpa、pdbの内容を検証するテストを追加。

- e2e/tests/docs_compliance/test_terraform.py:
  - Terraformのobservabilityモジュールに関するテストを追加。
  - databaseおよびharborモジュールのテストを追加。

- infra/messaging/saga/workflows/order-fulfillment.yaml:
  - 注文処理のためのSagaワークフローを追加。

- infra/observability/grafana/dashboards/overview.json:
  - Grafanaのオーバービュー用ダッシュボードを追加。

- infra/observability/grafana/dashboards/slo.json:
  - SLO用のGrafanaダッシュボードを追加。