### PR TITLE
feat: docs 設計に対する OSS 実装ギャップ 5 領域を解消（envoy-gateway / analysis-templates / GitOps ルート / README 群 / SHIP_STATUS）

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,89 @@
+# deploy — k1s0 GitOps 配信定義
+
+本ディレクトリは Argo CD / Argo Rollouts / Helm chart / Kustomize / OpenTofu の配信ソースを統合する。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/01_deploy配置_GitOps.md`](../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/01_deploy配置_GitOps.md)。
+
+## 配置構造
+
+```text
+deploy/
+├── README.md                           # 本ファイル
+├── apps/                               # Argo CD Application / ApplicationSet
+│   ├── app-of-apps.yaml                # ルート Application（手動 apply の唯一）
+│   ├── application-sets/               # カテゴリ別 ApplicationSet
+│   │   ├── infra.yaml                  # infra/environments/<env>/ 配備（Wave -10）
+│   │   ├── ops.yaml                    # ops（Backstage / chaos / runbook）配備（Wave 40〜45）
+│   │   ├── tier1-facade.yaml           # tier1 Go 3 Pod
+│   │   ├── tier1-rust-service.yaml     # tier1 Rust 3 Pod
+│   │   ├── tier2-dotnet-service.yaml   # tier2 .NET ドメインサービス
+│   │   ├── tier2-go-service.yaml       # tier2 Go ドメインサービス
+│   │   ├── tier3-bff.yaml              # tier3 BFF（portal-bff / admin-bff）
+│   │   └── tier3-web-app.yaml          # tier3 Web SPA（portal / admin / docs-site）
+│   └── projects/                       # AppProject（RBAC 境界）
+│       ├── k1s0-platform.yaml          # umbrella（infra / ops / GitOps ルート）
+│       ├── k1s0-tier1.yaml             # tier1 専用境界
+│       ├── k1s0-tier2.yaml             # tier2 専用境界
+│       ├── k1s0-tier3.yaml             # tier3 専用境界
+│       └── rbac.yaml                   # Argo CD グローバル RBAC（OIDC 連携）
+├── charts/                             # Helm chart 6 種
+│   ├── tier1-facade/                   # Go 3 Pod 共通 chart
+│   ├── tier1-rust-service/             # Rust 3 Pod ループ
+│   ├── tier2-go-service/               # 汎用 Go テンプレ
+│   ├── tier2-dotnet-service/           # 汎用 .NET テンプレ
+│   ├── tier3-bff/                      # Go BFF テンプレ
+│   └── tier3-web-app/                  # nginx + SPA + reverse proxy
+├── kustomize/                          # 環境別 overlay
+│   ├── base/                           # 共通 Namespace + label
+│   └── overlays/{dev,staging,prod}/    # 6 chart × 3 環境 = 18 values overlay
+├── rollouts/                           # Argo Rollouts 関連
+│   ├── canary-strategies/              # canary 25→50→100 段階戦略
+│   ├── analysis/                       # ★ 共通 ClusterAnalysisTemplate 5 本（IMP-REL-AT-040〜044）
+│   ├── analysis-templates/             # サービス固有 AnalysisTemplate 例
+│   └── experiments/                    # 採用後の運用拡大時 で追加
+├── image-updater/                      # Argo CD Image Updater 設定
+└── opentofu/                           # OpenTofu モジュール（採用後の運用拡大時）
+    ├── environments/{dev,staging,prod}/
+    └── modules/{vpn-gateway,dns,baremetal-k8s}/
+```
+
+## Sync Wave の設計
+
+Argo CD の `argocd.argoproj.io/sync-wave` annotation で起動順序を制御する。
+詳細は [`docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md`](../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md)。
+
+| Wave | 対象 | 前提条件 |
+|------|------|----------|
+| -10 | Operator + CRD（CNPG / Strimzi / Istio CNI / Dapr Operator / cert-manager / SPIRE） | （クラスタ初期化完了） |
+| -5 | CR 宣言（Dapr Components / Istio AuthorizationPolicy / KRaft Cluster CR） | Operator が CRD 認識済み |
+| 0 | data backend（CNPG Cluster / Kafka Cluster / MinIO / Valkey）+ LGTM | CRD 認識済み |
+| 10 | tier1（Go ファサード 3 Pod + Rust 3 Pod） | data backend Ready |
+| 20 | tier2（.NET / Go ドメインサービス） | tier1 公開 API Ready |
+| 30 | tier3（Web / BFF / Native は image 配布外 / Legacy wrap） | tier2 ドメインサービス Ready |
+| 40〜45 | ops（Backstage / chaos / runbook） | アプリ Pod 起動完了 |
+
+## デプロイ手順（Argo CD 初期化）
+
+```sh
+# 1. Argo CD を install（infra/ から）
+kubectl apply -f infra/k8s/namespaces/argocd.yaml
+helm install argocd argo/argo-cd --namespace argocd --create-namespace
+
+# 2. AppProject 群を先に apply（app-of-apps の前提）
+kubectl apply -f deploy/apps/projects/
+
+# 3. RBAC ConfigMap を apply
+kubectl apply -f deploy/apps/projects/rbac.yaml
+
+# 4. ルート Application を apply（以後は ApplicationSet が自動展開）
+kubectl apply -f deploy/apps/app-of-apps.yaml
+```
+
+以降の更新は **Git PR のみ**。`kubectl apply` を二度と打たない（GitOps 原則）。
+
+## 関連設計
+
+- [ADR-CICD-001](../docs/02_構想設計/adr/ADR-CICD-001-gitops.md) — GitOps（Argo CD）採用
+- [ADR-CICD-002](../docs/02_構想設計/adr/ADR-CICD-002-argo-rollouts.md) — Argo Rollouts（progressive delivery）
+- [ADR-REL-001](../docs/02_構想設計/adr/ADR-REL-001-progressive-delivery-required.md) — PD 必須化
+- [IMP-DIR-OPS-092](../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md) — ApplicationSet 配置
+- [`docs/05_実装/70_リリース設計/40_AnalysisTemplate/`](../docs/05_実装/70_リリース設計/40_AnalysisTemplate/) — 共通 ClusterAnalysisTemplate 5 本

--- a/deploy/apps/app-of-apps.yaml
+++ b/deploy/apps/app-of-apps.yaml
@@ -1,0 +1,40 @@
+# 本ファイルは Argo CD の App-of-Apps ルート Application（IMP-DIR-OPS-092）。
+# Argo CD 初期化時に **手動で apply する唯一の Application**。
+# 以後は本 Application が `deploy/apps/application-sets/` 配下の全 ApplicationSet を
+# 子として展開（recurse: true）し、各 ApplicationSet が個別の Application を生成する。
+#
+# 詳細設計: docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-of-apps
+  namespace: argocd
+  labels:
+    k1s0.io/component: gitops-root
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: k1s0-platform
+  source:
+    repoURL: https://github.com/k1s0/k1s0.git
+    targetRevision: HEAD
+    path: deploy/apps/application-sets
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - ServerSideApply=true
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/apps/application-sets/infra.yaml
+++ b/deploy/apps/application-sets/infra.yaml
@@ -1,0 +1,59 @@
+# 本ファイルは infra/environments/<env>/ 全体を Argo CD で配備する ApplicationSet。
+# list-generator で dev / staging / prod の 3 環境を固定し、それぞれの cluster に
+# kustomize build 結果（CNPG / Kafka / MinIO / Valkey / LGTM / Istio / Envoy Gateway / Dapr 等）を sync する。
+#
+# Sync Wave -10〜0 で Operator + CRD と data backend を起動。tier1 以降は
+# 別 ApplicationSet（tier1-facade.yaml 等）が Wave 10〜30 で起動する。
+#
+# 詳細設計: docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: infra
+  namespace: argocd
+  labels:
+    k1s0.io/component: gitops-infra
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - env: dev
+            cluster: https://kubernetes.default.svc
+          - env: staging
+            cluster: https://staging.k1s0.internal
+          - env: prod
+            cluster: https://prod.k1s0.internal
+  template:
+    metadata:
+      name: "infra-{{.env}}"
+      labels:
+        k1s0.io/component: infra
+        k1s0.io/env: "{{.env}}"
+      annotations:
+        argocd.argoproj.io/sync-wave: "-10"
+    spec:
+      project: k1s0-platform
+      source:
+        repoURL: https://github.com/k1s0/k1s0.git
+        targetRevision: HEAD
+        path: "infra/environments/{{.env}}"
+      destination:
+        server: "{{.cluster}}"
+        namespace: ""
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+          allowEmpty: false
+        syncOptions:
+          - ServerSideApply=true
+          - CreateNamespace=true
+          - PruneLast=true
+          - ApplyOutOfSyncOnly=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 10m

--- a/deploy/apps/application-sets/ops.yaml
+++ b/deploy/apps/application-sets/ops.yaml
@@ -1,0 +1,62 @@
+# 本ファイルは ops 系ツール（Backstage 開発者ポータル / LitmusChaos / Runbook サーバ）を配備する ApplicationSet。
+# Sync Wave 40 で展開し、tier1〜tier3 のアプリ Pod 起動完了後に運用ツールを順次立ち上げる。
+# Backstage は別途 `infra/k8s/namespaces/k1s0-platform-tools.yaml` で namespace 確保済み前提。
+#
+# 詳細設計:
+#   docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md
+#   docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/06_Backstage_プラグイン配置.md
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ops
+  namespace: argocd
+  labels:
+    k1s0.io/component: gitops-ops
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - app: backstage
+            path: ops/backstage
+            namespace: k1s0-platform-tools
+            wave: "40"
+          - app: chaos
+            path: ops/chaos
+            namespace: k1s0-chaos
+            wave: "45"
+          - app: runbooks
+            path: ops/runbooks
+            namespace: k1s0-platform-tools
+            wave: "45"
+  template:
+    metadata:
+      name: "ops-{{.app}}"
+      labels:
+        k1s0.io/component: ops
+        k1s0.io/app: "{{.app}}"
+      annotations:
+        argocd.argoproj.io/sync-wave: "{{.wave}}"
+    spec:
+      project: k1s0-platform
+      source:
+        repoURL: https://github.com/k1s0/k1s0.git
+        targetRevision: HEAD
+        path: "{{.path}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{.namespace}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+          allowEmpty: false
+        syncOptions:
+          - ServerSideApply=true
+          - CreateNamespace=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 30s
+            factor: 2
+            maxDuration: 5m

--- a/deploy/apps/projects/k1s0-platform.yaml
+++ b/deploy/apps/projects/k1s0-platform.yaml
@@ -1,0 +1,52 @@
+# 本ファイルは k1s0 全体の umbrella AppProject「k1s0-platform」。
+# infra / ops / app-of-apps が所属し、tier1 / tier2 / tier3 の各 AppProject に
+# 直接所属しないリソース（Cluster 級 CRD / Operator / 観測性 / 開発者ポータル）を扱う。
+# クラスタ越境（dev / staging / prod の 3 cluster）を許可することで GitOps を一元化する。
+#
+# 詳細設計: docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: k1s0-platform
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  labels:
+    k1s0.io/scope: platform
+spec:
+  description: |
+    k1s0 全体の umbrella AppProject。infra / ops / GitOps ルート Application を所属させ、
+    Cluster 級リソース（Operator / CRD / Mesh / Observability）の同期を許可する。
+  sourceRepos:
+    - https://github.com/k1s0/k1s0.git
+  destinations:
+    - namespace: "*"
+      server: https://kubernetes.default.svc
+    - namespace: "*"
+      server: https://dev.k1s0.internal
+    - namespace: "*"
+      server: https://staging.k1s0.internal
+    - namespace: "*"
+      server: https://prod.k1s0.internal
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+  roles:
+    - name: admin
+      description: SRE / Platform team 管理者ロール
+      policies:
+        - p, proj:k1s0-platform:admin, applications, *, k1s0-platform/*, allow
+        - p, proj:k1s0-platform:admin, repositories, *, *, allow
+      groups:
+        - k1s0:sre-ops
+        - k1s0:platform-admin
+    - name: viewer
+      description: 開発者向け閲覧専用ロール
+      policies:
+        - p, proj:k1s0-platform:viewer, applications, get, k1s0-platform/*, allow
+        - p, proj:k1s0-platform:viewer, applications, sync, k1s0-platform/*, deny
+      groups:
+        - k1s0:developers

--- a/deploy/apps/projects/rbac.yaml
+++ b/deploy/apps/projects/rbac.yaml
@@ -1,0 +1,53 @@
+# 本ファイルは Argo CD グローバル RBAC（SSO 連携）の ConfigMap 定義。
+# Keycloak の OIDC 経由で `groups` claim を受け取り、Argo CD 内の role に写像する。
+# Argo CD admin UI 操作と CLI 操作の両方に適用される。
+#
+# 詳細設計: docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  policy.default: role:readonly
+  policy.csv: |
+    # SRE / Platform 管理者 — 全プロジェクト admin
+    p, role:platform-admin, applications, *, */*, allow
+    p, role:platform-admin, clusters, *, *, allow
+    p, role:platform-admin, repositories, *, *, allow
+    p, role:platform-admin, projects, *, *, allow
+    p, role:platform-admin, accounts, *, *, allow
+    p, role:platform-admin, gpgkeys, *, *, allow
+    p, role:platform-admin, certificates, *, *, allow
+
+    # tier1 開発者 — k1s0-tier1 配下のみ sync 可能
+    p, role:tier1-developer, applications, get, k1s0-tier1/*, allow
+    p, role:tier1-developer, applications, sync, k1s0-tier1/*, allow
+    p, role:tier1-developer, logs, get, k1s0-tier1/*, allow
+
+    # tier2 開発者 — k1s0-tier2 配下のみ sync 可能
+    p, role:tier2-developer, applications, get, k1s0-tier2/*, allow
+    p, role:tier2-developer, applications, sync, k1s0-tier2/*, allow
+    p, role:tier2-developer, logs, get, k1s0-tier2/*, allow
+
+    # tier3 開発者 — k1s0-tier3 配下のみ sync 可能
+    p, role:tier3-developer, applications, get, k1s0-tier3/*, allow
+    p, role:tier3-developer, applications, sync, k1s0-tier3/*, allow
+    p, role:tier3-developer, logs, get, k1s0-tier3/*, allow
+
+    # 全社員 — 閲覧専用
+    p, role:readonly, applications, get, */*, allow
+    p, role:readonly, projects, get, *, allow
+    p, role:readonly, logs, get, */*, allow
+
+    # Keycloak `groups` claim → Argo CD role の写像
+    g, k1s0:sre-ops, role:platform-admin
+    g, k1s0:platform-admin, role:platform-admin
+    g, k1s0:tier1-team, role:tier1-developer
+    g, k1s0:tier2-team, role:tier2-developer
+    g, k1s0:tier3-team, role:tier3-developer
+    g, k1s0:developers, role:readonly
+  scopes: "[groups]"

--- a/deploy/charts/predeploy-hooks/Chart.yaml
+++ b/deploy/charts/predeploy-hooks/Chart.yaml
@@ -1,0 +1,21 @@
+# 本ファイルは Argo CD PreSync Hook Job 群を束ねる Helm chart の Chart.yaml。
+# Wave -5 で宣言された Dapr Component CR の backing store（Postgres / Kafka /
+# Valkey / MinIO）の Ready 状態を polling 検証する Job 4 種を提供する。
+# 参照設計: docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md
+apiVersion: v2
+name: predeploy-hooks
+description: "Argo CD PreSync Hook Jobs — backing store readiness gate for k1s0 GitOps Wave control"
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - argocd
+  - presync-hook
+  - readiness
+  - k1s0
+maintainers:
+  - name: k1s0-platform-team
+    email: platform@k1s0.example
+annotations:
+  k1s0.io/component: predeploy-hooks
+  k1s0.io/sync-wave: "-1"

--- a/deploy/charts/predeploy-hooks/README.md
+++ b/deploy/charts/predeploy-hooks/README.md
@@ -1,0 +1,69 @@
+# deploy/charts/predeploy-hooks — Argo CD PreSync Hook Jobs
+
+Argo CD の `PreSync` Hook で、Wave -5 で宣言された Dapr Component CR の backing store
+（Postgres / Kafka / Valkey / MinIO）の Ready 状態を polling 検証する。
+Wave 10 で tier1 Pod が起動する前に backing store の利用可能性を確認することで、
+「CR は登録されたが実体が起動していない」「DNS は解決するが TCP/HTTP が通らない」状態でアプリ Pod が
+起動して接続失敗が連鎖する事故を防ぐ。
+
+詳細設計: [`docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md`](../../../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md) の
+「backing store との接続タイミング」節。
+
+## Job 一覧（4 種）
+
+| ファイル | 検証対象 | image | 検証方法 |
+|---|---|---|---|
+| `templates/job-postgres-ready.yaml` | Postgres（CNPG） | `postgres:16-alpine` | `pg_isready` |
+| `templates/job-kafka-ready.yaml` | Kafka（Strimzi KRaft） | `busybox:1.36` | TCP probe（`nc -z`） |
+| `templates/job-valkey-ready.yaml` | Valkey | `valkey/valkey:7.2-alpine` | `valkey-cli ping` |
+| `templates/job-minio-ready.yaml` | MinIO | `curlimages/curl:8.10.1` | HTTP `/minio/health/ready` |
+
+各 Job は ServiceAccount `predeploy-hooks` で動作し、`securityContext` で nonroot / readOnlyRootFilesystem /
+all capabilities drop / RuntimeDefault seccomp を強制する（Pod Security Standards `restricted` 準拠）。
+
+## Argo CD Hook 動作
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync                         # Sync 直前に実行
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"                       # Wave 0 直前
+```
+
+`PreSync` Hook は Sync の各サイクルで Argo CD が自動的に再生成する。`HookSucceeded` で成功時削除、
+`BeforeHookCreation` で前回 Job 残骸の事前削除を行うことで、再 Sync ごとにクリーンに動作する。
+
+## 適用
+
+```sh
+# Argo CD Application から参照（推奨）
+# deploy/apps/application-sets/infra.yaml が path: infra/environments/<env>/ で本 chart も含める
+
+# 直接 helm install（手動デプロイ用）
+helm install predeploy-hooks deploy/charts/predeploy-hooks \
+  --namespace argocd --create-namespace \
+  -f deploy/kustomize/overlays/<env>/predeploy-hooks-values.yaml
+```
+
+## 環境別 overlay（採用初期で配置）
+
+採用組織が values を環境別に上書きする例:
+
+```yaml
+# deploy/kustomize/overlays/dev/predeploy-hooks-values.yaml
+job:
+  polling:
+    intervalSeconds: 2          # dev は短く
+    timeoutSeconds: 60          # dev は短時間で諦める
+postgres:
+  service: cnpg-cluster-rw.k1s0-data-dev.svc.cluster.local
+kafka:
+  enabled: false                # dev は Kafka 起動しない構成も許容
+```
+
+## 関連設計
+
+- [docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md](../../../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md) — backing store 接続タイミング
+- [ADR-CICD-002](../../../docs/02_構想設計/adr/ADR-CICD-002-argo-rollouts.md) — Argo CD
+- [IMP-DIR-OPS-092](../../../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/02_ArgoCD_ApplicationSet配置.md) — ApplicationSet 配置

--- a/deploy/charts/predeploy-hooks/templates/_helpers.tpl
+++ b/deploy/charts/predeploy-hooks/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{/*
+本ファイルは predeploy-hooks Helm chart の共通テンプレート関数。
+Helm 推奨パターンに従い、name / fullname / labels の helper を集約する。
+*/}}
+
+{{- define "predeploy-hooks.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "predeploy-hooks.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "predeploy-hooks.labels" -}}
+app.kubernetes.io/name: {{ include "predeploy-hooks.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+k1s0.io/component: predeploy-hooks
+{{- end -}}

--- a/deploy/charts/predeploy-hooks/templates/job-kafka-ready.yaml
+++ b/deploy/charts/predeploy-hooks/templates/job-kafka-ready.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.kafka.enabled }}
+# 本ファイルは Kafka（Strimzi KRaft Cluster）の Ready 状態を polling 検証する PreSync Job。
+# `kafka-cluster-kafka-bootstrap` Service の TCP 接続性のみを確認する（mTLS 通過は
+# tier1 Pod 起動時に Dapr sidecar が検証するため、ここでは TCP レベルに留める）。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "predeploy-hooks.fullname" . }}-kafka-ready
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+    k1s0.io/check: kafka-ready
+  annotations:
+    argocd.argoproj.io/hook: {{ .Values.job.hook }}
+    argocd.argoproj.io/hook-delete-policy: {{ .Values.job.hookDeletePolicy }}
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "predeploy-hooks.labels" . | nindent 8 }}
+        k1s0.io/check: kafka-ready
+    spec:
+      serviceAccountName: {{ .Values.job.serviceAccountName }}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kafka-tcp-check
+          image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: KAFKA_HOST
+              value: {{ .Values.kafka.service | quote }}
+            - name: KAFKA_PORT
+              value: {{ .Values.kafka.port | quote }}
+            - name: POLL_INTERVAL
+              value: {{ .Values.job.polling.intervalSeconds | quote }}
+            - name: TIMEOUT
+              value: {{ .Values.job.polling.timeoutSeconds | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              DEADLINE=$(( $(date +%s) + ${TIMEOUT} ))
+              while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+                if nc -z -w 5 "${KAFKA_HOST}" "${KAFKA_PORT}"; then
+                  echo "[predeploy-hooks] Kafka Ready: ${KAFKA_HOST}:${KAFKA_PORT}"
+                  exit 0
+                fi
+                echo "[predeploy-hooks] Kafka NotReady, retrying in ${POLL_INTERVAL}s..."
+                sleep "${POLL_INTERVAL}"
+              done
+              echo "[predeploy-hooks] Kafka readiness timeout after ${TIMEOUT}s" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+{{- end }}

--- a/deploy/charts/predeploy-hooks/templates/job-minio-ready.yaml
+++ b/deploy/charts/predeploy-hooks/templates/job-minio-ready.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.minio.enabled }}
+# 本ファイルは MinIO（S3 互換オブジェクトストレージ）の Ready 状態を polling 検証する PreSync Job。
+# MinIO `/minio/health/ready` エンドポイントを HTTP HEAD で叩いて 200 を確認する。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "predeploy-hooks.fullname" . }}-minio-ready
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+    k1s0.io/check: minio-ready
+  annotations:
+    argocd.argoproj.io/hook: {{ .Values.job.hook }}
+    argocd.argoproj.io/hook-delete-policy: {{ .Values.job.hookDeletePolicy }}
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "predeploy-hooks.labels" . | nindent 8 }}
+        k1s0.io/check: minio-ready
+    spec:
+      serviceAccountName: {{ .Values.job.serviceAccountName }}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: minio-health
+          image: "curlimages/curl:8.10.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: MINIO_HOST
+              value: {{ .Values.minio.service | quote }}
+            - name: MINIO_PORT
+              value: {{ .Values.minio.port | quote }}
+            - name: POLL_INTERVAL
+              value: {{ .Values.job.polling.intervalSeconds | quote }}
+            - name: TIMEOUT
+              value: {{ .Values.job.polling.timeoutSeconds | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              DEADLINE=$(( $(date +%s) + ${TIMEOUT} ))
+              URL="http://${MINIO_HOST}:${MINIO_PORT}/minio/health/ready"
+              while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+                if curl -fsS --max-time 5 -o /dev/null -w "%{http_code}" "${URL}" | grep -q '^200$'; then
+                  echo "[predeploy-hooks] MinIO Ready: ${URL}"
+                  exit 0
+                fi
+                echo "[predeploy-hooks] MinIO NotReady, retrying in ${POLL_INTERVAL}s..."
+                sleep "${POLL_INTERVAL}"
+              done
+              echo "[predeploy-hooks] MinIO readiness timeout after ${TIMEOUT}s" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 30m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+{{- end }}

--- a/deploy/charts/predeploy-hooks/templates/job-postgres-ready.yaml
+++ b/deploy/charts/predeploy-hooks/templates/job-postgres-ready.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.postgres.enabled }}
+# 本ファイルは Postgres（CNPG Cluster）の Ready 状態を polling 検証する PreSync Job。
+# Wave -5 で Dapr Component CR が宣言された後、Wave 0 で CNPG Cluster が立ち上がるが、
+# その後 tier1 Pod 起動（Wave 10）の前に本 Job が `pg_isready` で接続可能性を確認する。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "predeploy-hooks.fullname" . }}-postgres-ready
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+    k1s0.io/check: postgres-ready
+  annotations:
+    argocd.argoproj.io/hook: {{ .Values.job.hook }}
+    argocd.argoproj.io/hook-delete-policy: {{ .Values.job.hookDeletePolicy }}
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "predeploy-hooks.labels" . | nindent 8 }}
+        k1s0.io/check: postgres-ready
+    spec:
+      serviceAccountName: {{ .Values.job.serviceAccountName }}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pg-isready
+          image: "postgres:16-alpine"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: PGHOST
+              value: {{ .Values.postgres.service | quote }}
+            - name: PGPORT
+              value: {{ .Values.postgres.port | quote }}
+            - name: PGDATABASE
+              value: {{ .Values.postgres.database | quote }}
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.credentialsSecret }}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgres.credentialsSecret }}
+                  key: password
+            - name: POLL_INTERVAL
+              value: {{ .Values.job.polling.intervalSeconds | quote }}
+            - name: TIMEOUT
+              value: {{ .Values.job.polling.timeoutSeconds | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              DEADLINE=$(( $(date +%s) + ${TIMEOUT} ))
+              while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+                if pg_isready -h "${PGHOST}" -p "${PGPORT}" -d "${PGDATABASE}" -U "${PGUSER}" -t 5; then
+                  echo "[predeploy-hooks] Postgres Ready: ${PGHOST}:${PGPORT}/${PGDATABASE}"
+                  exit 0
+                fi
+                echo "[predeploy-hooks] Postgres NotReady, retrying in ${POLL_INTERVAL}s..."
+                sleep "${POLL_INTERVAL}"
+              done
+              echo "[predeploy-hooks] Postgres readiness timeout after ${TIMEOUT}s" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+{{- end }}

--- a/deploy/charts/predeploy-hooks/templates/job-valkey-ready.yaml
+++ b/deploy/charts/predeploy-hooks/templates/job-valkey-ready.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.valkey.enabled }}
+# 本ファイルは Valkey（Redis 互換キャッシュ）の Ready 状態を polling 検証する PreSync Job。
+# `redis-cli ping` 互換の TCP probe で接続性を確認する。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "predeploy-hooks.fullname" . }}-valkey-ready
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+    k1s0.io/check: valkey-ready
+  annotations:
+    argocd.argoproj.io/hook: {{ .Values.job.hook }}
+    argocd.argoproj.io/hook-delete-policy: {{ .Values.job.hookDeletePolicy }}
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "predeploy-hooks.labels" . | nindent 8 }}
+        k1s0.io/check: valkey-ready
+    spec:
+      serviceAccountName: {{ .Values.job.serviceAccountName }}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: valkey-ping
+          image: "valkey/valkey:7.2-alpine"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: VALKEY_HOST
+              value: {{ .Values.valkey.service | quote }}
+            - name: VALKEY_PORT
+              value: {{ .Values.valkey.port | quote }}
+            - name: VALKEY_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.valkey.authSecret }}
+                  key: password
+            - name: POLL_INTERVAL
+              value: {{ .Values.job.polling.intervalSeconds | quote }}
+            - name: TIMEOUT
+              value: {{ .Values.job.polling.timeoutSeconds | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              DEADLINE=$(( $(date +%s) + ${TIMEOUT} ))
+              while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+                if valkey-cli -h "${VALKEY_HOST}" -p "${VALKEY_PORT}" -a "${VALKEY_AUTH}" --no-auth-warning ping | grep -q PONG; then
+                  echo "[predeploy-hooks] Valkey Ready: ${VALKEY_HOST}:${VALKEY_PORT}"
+                  exit 0
+                fi
+                echo "[predeploy-hooks] Valkey NotReady, retrying in ${POLL_INTERVAL}s..."
+                sleep "${POLL_INTERVAL}"
+              done
+              echo "[predeploy-hooks] Valkey readiness timeout after ${TIMEOUT}s" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 30m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+{{- end }}

--- a/deploy/charts/predeploy-hooks/templates/serviceaccount.yaml
+++ b/deploy/charts/predeploy-hooks/templates/serviceaccount.yaml
@@ -1,0 +1,44 @@
+# 本ファイルは predeploy-hooks 用の ServiceAccount + Role + RoleBinding。
+# Job が backing store の Secret を読むためのみ使用される最小権限。
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: predeploy-hooks
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: predeploy-hooks-secrets-reader
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: predeploy-hooks-secrets-reader
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "predeploy-hooks.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: predeploy-hooks-secrets-reader
+subjects:
+  - kind: ServiceAccount
+    name: predeploy-hooks
+    namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/predeploy-hooks/values.yaml
+++ b/deploy/charts/predeploy-hooks/values.yaml
@@ -1,0 +1,52 @@
+# 本ファイルは predeploy-hooks Helm chart の既定 values。
+# 各 backing store（Postgres / Kafka / Valkey / MinIO）の Service / Port / 認証情報を
+# 環境別 overlay（deploy/kustomize/overlays/<env>/predeploy-hooks-values.yaml）で上書きする。
+
+# Job 共通設定
+job:
+  # PreSync Hook 動作の基本設定。
+  hook: PreSync
+  # Hook 完了後 / 失敗後に削除する。
+  hookDeletePolicy: HookSucceeded,BeforeHookCreation
+  # 異常終了時の再試行回数（指数バックオフは shell 側で実装）。
+  backoffLimit: 5
+  # 1 Job あたりの最大実行時間（秒）。これを超えたら異常停止扱い。
+  activeDeadlineSeconds: 600
+  # Job pod の RBAC（ServiceAccount は templates/serviceaccount.yaml で生成）。
+  serviceAccountName: predeploy-hooks
+  # 共通 image（busybox + curl）。distroless ではなく busybox を選ぶのは sleep / echo / nc 等を
+  # 1 image で完結させるため（cold start を高速化）。
+  image:
+    repository: busybox
+    tag: "1.36"
+  # 共通 polling 設定。
+  polling:
+    intervalSeconds: 5
+    timeoutSeconds: 300
+
+# 各 backing store の接続情報。
+# values は環境別 overlay で上書きする想定。
+postgres:
+  enabled: true
+  service: cnpg-cluster-rw.k1s0-data.svc.cluster.local
+  port: 5432
+  database: k1s0
+  # secret 経由で認証情報を取る（ServiceAccount は dataStore に read 権限）。
+  credentialsSecret: cnpg-app-credentials
+kafka:
+  enabled: true
+  service: kafka-cluster-kafka-bootstrap.k1s0-messaging.svc.cluster.local
+  port: 9092
+  # mTLS 経由（cert-manager 発行）。
+  certSecret: kafka-client-cert
+valkey:
+  enabled: true
+  service: valkey-headless.k1s0-data.svc.cluster.local
+  port: 6379
+  authSecret: valkey-credentials
+minio:
+  enabled: true
+  service: minio.k1s0-data.svc.cluster.local
+  port: 9000
+  credentialsSecret: minio-credentials
+  bucket: k1s0

--- a/deploy/rollouts/analysis/README.md
+++ b/deploy/rollouts/analysis/README.md
@@ -1,0 +1,70 @@
+# deploy/rollouts/analysis — 共通 ClusterAnalysisTemplate 5 本（IMP-REL-AT-040〜049）
+
+ADR-REL-001（PD 必須化）/ ADR-CICD-002（Argo Rollouts）/ `docs/05_実装/70_リリース設計/40_AnalysisTemplate/01_AnalysisTemplate設計.md` に従い、
+k1s0 全サービスが共通利用する 5 本の `ClusterAnalysisTemplate` を一元配置する。
+サービス固有 AnalysisTemplate は本セットを `templateRef` で継承し、固有指標のみを差分追加する。
+
+## なぜ共通 5 本セットか
+
+各サービスが独自に AnalysisTemplate を書くと、PromQL クエリの記法揺れ・閾値設定の不統一・provider 接続文字列の重複が発生し、
+SRE が SLI 改訂時にすべてのサービスをスキャンしなければならない事態が生じる。
+共通テンプレを cluster スコープで一元配置することで、SLO 改訂時の影響面が「共通テンプレを 1 箇所変更」に集約される。
+
+## ファイル一覧
+
+| ファイル | IMP-ID | 主題 | failureLimit / count | 失敗条件 |
+|---|---|---|---|---|
+| `at-common-error-rate.yaml` | IMP-REL-AT-040 | error rate baseline 2σ 超過 | 2 / 5 | 5xx 比率が 30 分 baseline + 2σ を超過 |
+| `at-common-latency-p99.yaml` | IMP-REL-AT-041 | レイテンシ p99 SLO 連動 | 2 / 5 | p99 が args 渡し SLO 値超過 |
+| `at-common-cpu.yaml` | IMP-REL-AT-042 | CPU 飽和の早期検知 | 8 / 10 | CPU 使用率 80% を 10 分中 8 分以上 |
+| `at-common-dependency-down.yaml` | IMP-REL-AT-043 | 依存断短絡判定 | 1 / 3 | Postgres/Kafka/Valkey の `up` が 0 |
+| `at-common-error-budget-burn.yaml` | IMP-REL-AT-044 | エラーバジェット fast burn | 2 / 3 | `api:burn_rate_1h` が 2x 超過（14 日枯渇ペース） |
+
+## デプロイ
+
+```sh
+# Argo CD が cluster スコープで apply（k1s0-platform AppProject から）
+kubectl apply -f deploy/rollouts/analysis/
+
+# 確認
+kubectl get clusteranalysistemplates
+```
+
+## サービス側の参照
+
+```yaml
+# deploy/charts/<service>/templates/rollout.yaml
+spec:
+  strategy:
+    canary:
+      steps:
+        - setWeight: 25
+        - analysis:
+            templates:
+              - templateName: at-common-error-rate
+                clusterScope: true
+              - templateName: at-common-latency-p99
+                clusterScope: true
+            args:
+              - name: service-name
+                value: tier1-state
+              - name: namespace
+                value: k1s0-tier1
+              - name: slo-latency-seconds
+                value: "0.1"
+```
+
+サービス固有テンプレ（namespace スコープ AnalysisTemplate）は `deploy/charts/<service>/templates/analysis-template.yaml` に配置し、
+共通セットを `templateRef` で参照しつつドメイン固有指標（Temporal completion rate / ZEN Engine 確信度等）を差分追加する。
+
+## カバレッジと監査
+
+共通 5 本でカバーできる SLO 評価範囲は約 80%（error / latency / capacity / dependency / budget の 5 軸）。
+残 20% はサービス固有テンプレが補完する。月次カバレッジ計測は `tools/scorecard/at-coverage.sh`（IMP-REL-AT-048）。
+
+## 関連設計
+
+- [ADR-CICD-002](../../../docs/02_構想設計/adr/ADR-CICD-002-argo-rollouts.md) — Argo Rollouts
+- [ADR-REL-001](../../../docs/02_構想設計/adr/ADR-REL-001-progressive-delivery-required.md) — PD 必須化
+- [ADR-OBS-001](../../../docs/02_構想設計/adr/ADR-OBS-001-grafana-lgtm.md) — Grafana LGTM
+- [docs/05_実装/70_リリース設計/40_AnalysisTemplate/01_AnalysisTemplate設計.md](../../../docs/05_実装/70_リリース設計/40_AnalysisTemplate/01_AnalysisTemplate設計.md)

--- a/deploy/rollouts/analysis/at-common-cpu.yaml
+++ b/deploy/rollouts/analysis/at-common-cpu.yaml
@@ -1,0 +1,28 @@
+# 本ファイルは共通 ClusterAnalysisTemplate「at-common-cpu」（IMP-REL-AT-042）。
+# Pod の CPU 使用率が 80% を 10 分継続で fail とする。HPA scale-up が間に合わず
+# スループット低下する前段で検知する目的。count 10 + failureLimit 8 で
+# 「10 分中 8 分超過」を意味し、瞬間スパイクを許容しつつ持続的飽和のみ検知する。
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterAnalysisTemplate
+metadata:
+  name: at-common-cpu
+  labels:
+    k1s0.io/component: analysis-template
+    k1s0.io/scope: cluster
+    k1s0.io/imp-id: IMP-REL-AT-042
+spec:
+  args:
+    - name: service-name
+    - name: namespace
+  metrics:
+    - name: cpu-utilization-sustained
+      interval: 1m
+      count: 10
+      failureLimit: 8
+      provider:
+        prometheus:
+          address: http://mimir-query-frontend.k1s0-observability:8080/prometheus
+          query: |
+            avg(rate(container_cpu_usage_seconds_total{namespace="{{args.namespace}}",container="{{args.service-name}}"}[2m])
+                / on (pod) kube_pod_container_resource_limits{resource="cpu"})
+      failureCondition: result[0] > 0.8

--- a/deploy/rollouts/analysis/at-common-dependency-down.yaml
+++ b/deploy/rollouts/analysis/at-common-dependency-down.yaml
@@ -1,0 +1,24 @@
+# 本ファイルは共通 ClusterAnalysisTemplate「at-common-dependency-down」（IMP-REL-AT-043）。
+# 依存コンポーネント（Postgres / Kafka / Valkey）の `up` が 0 になった瞬間に fail。
+# failureLimit 1 で短絡判定し、依存断時は Canary 進行を即座に止めて
+# トラフィックを依存断状態に流さないようにする。手動 resume が必要。
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterAnalysisTemplate
+metadata:
+  name: at-common-dependency-down
+  labels:
+    k1s0.io/component: analysis-template
+    k1s0.io/scope: cluster
+    k1s0.io/imp-id: IMP-REL-AT-043
+spec:
+  metrics:
+    - name: dependency-availability
+      interval: 30s
+      count: 3
+      failureLimit: 1
+      provider:
+        prometheus:
+          address: http://mimir-query-frontend.k1s0-observability:8080/prometheus
+          query: |
+            min(up{job=~"postgres|kafka|valkey",namespace=~"k1s0-data|k1s0-messaging"})
+      failureCondition: result[0] == 0

--- a/deploy/rollouts/analysis/at-common-error-budget-burn.yaml
+++ b/deploy/rollouts/analysis/at-common-error-budget-burn.yaml
@@ -1,0 +1,26 @@
+# 本ファイルは共通 ClusterAnalysisTemplate「at-common-error-budget-burn」（IMP-REL-AT-044）。
+# `60_観測性設計/50_ErrorBudget運用/` の burn rate が 2x（fast burn）を超過したら fail。
+# burn rate 2x = バジェットを 14 日で枯渇するペース（28 日 SLO バジェット ÷ 2 = 14 日）。
+# fail 時は Argo Rollouts が abort し、後続で Git revert PR と PagerDuty Sev2 を発火。
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterAnalysisTemplate
+metadata:
+  name: at-common-error-budget-burn
+  labels:
+    k1s0.io/component: analysis-template
+    k1s0.io/scope: cluster
+    k1s0.io/imp-id: IMP-REL-AT-044
+spec:
+  args:
+    - name: service-name
+  metrics:
+    - name: error-budget-burn-rate
+      interval: 5m
+      count: 3
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://mimir-query-frontend.k1s0-observability:8080/prometheus
+          query: |
+            api:burn_rate_1h{service="{{args.service-name}}"}
+      failureCondition: result[0] > 2.0

--- a/deploy/rollouts/analysis/at-common-error-rate.yaml
+++ b/deploy/rollouts/analysis/at-common-error-rate.yaml
@@ -1,0 +1,38 @@
+# 本ファイルは共通 ClusterAnalysisTemplate「at-common-error-rate」（IMP-REL-AT-040）。
+# Argo Rollouts canary 進行中、新リリース版の error rate（5xx + gRPC error）が
+# baseline 期間（Canary 開始直前 30 分）と比較して 2σ 超過した場合に fail とする。
+# baseline は Mimir 側の recording rule `error_rate_baseline_30min` を事前計算しておく。
+# failureLimit 2 は「単発スパイクで rollback しない、2 連続 NG（2 分間）で fail 確定」。
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterAnalysisTemplate
+metadata:
+  name: at-common-error-rate
+  labels:
+    k1s0.io/component: analysis-template
+    k1s0.io/scope: cluster
+    k1s0.io/imp-id: IMP-REL-AT-040
+spec:
+  args:
+    - name: service-name
+    - name: namespace
+  metrics:
+    - name: error-rate-vs-baseline
+      interval: 1m
+      count: 5
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://mimir-query-frontend.k1s0-observability:8080/prometheus
+          query: |
+            (
+              sum(rate(http_requests_total{service="{{args.service-name}}",namespace="{{args.namespace}}",code=~"5.."}[5m]))
+              /
+              sum(rate(http_requests_total{service="{{args.service-name}}",namespace="{{args.namespace}}"}[5m]))
+            )
+            >
+            (
+              avg_over_time(error_rate_baseline_30min{service="{{args.service-name}}"}[30m])
+              + 2 * stddev_over_time(error_rate_baseline_30min{service="{{args.service-name}}"}[30m])
+            )
+      successCondition: result[0] == 0
+      failureCondition: result[0] == 1

--- a/deploy/rollouts/analysis/at-common-latency-p99.yaml
+++ b/deploy/rollouts/analysis/at-common-latency-p99.yaml
@@ -1,0 +1,29 @@
+# 本ファイルは共通 ClusterAnalysisTemplate「at-common-latency-p99」（IMP-REL-AT-041）。
+# レイテンシ p99 がサービス別 SLO 値（args 経由で渡す）を超過した場合に fail とする。
+# SLO 値の典型: tier1=0.1s / tier2=0.2s / tier3=0.5s（60_観測性設計/40_SLI_SLO定義 で定義）。
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterAnalysisTemplate
+metadata:
+  name: at-common-latency-p99
+  labels:
+    k1s0.io/component: analysis-template
+    k1s0.io/scope: cluster
+    k1s0.io/imp-id: IMP-REL-AT-041
+spec:
+  args:
+    - name: service-name
+    - name: namespace
+    - name: slo-latency-seconds
+  metrics:
+    - name: latency-p99-slo
+      interval: 1m
+      count: 5
+      failureLimit: 2
+      provider:
+        prometheus:
+          address: http://mimir-query-frontend.k1s0-observability:8080/prometheus
+          query: |
+            histogram_quantile(0.99,
+              sum by (le) (rate(http_request_duration_seconds_bucket{service="{{args.service-name}}",namespace="{{args.namespace}}"}[5m]))
+            )
+      failureCondition: result[0] > {{args.slo-latency-seconds}}

--- a/docs/SHIP_STATUS.md
+++ b/docs/SHIP_STATUS.md
@@ -1,0 +1,230 @@
+# 実装マチュリティ開示（SHIP STATUS）
+
+本ファイルは k1s0 リポジトリの**実装側の現状**と**docs（設計側）の規定**との
+ギャップを領域別に開示する。docs（約 658 ファイル / 5.3 万行）が記述する全体像と、
+実際に `git clone` 直後にビルド・起動できる範囲との差分は大きい。
+OSS 採用検討者が誤った前提で評価しないよう、本ファイルは現状を**段階表 3 ランク**で
+正直に記述する。
+
+## 想定読者
+
+- k1s0 を採用検討中のアーキテクト・SRE
+- リポジトリを clone してから「何が動き、何が動かないか」を最短で知りたい開発者
+- docs のリリース範囲表（README「リリース範囲」節）の実装側の裏付けを確認したい人
+
+## 前提となる用語（docs 正典）
+
+docs では構成要素を以下 3 段階で論じている。本ファイルもこの語彙に揃える。
+
+| 段階 | 意味 | docs 内典型例 |
+|---|---|---|
+| **リリース時点** | OSS 公開（v0 タグ）時点で同梱されるべき範囲 | 12 公開 API contracts / 主要 ADR / 採用初期スタック |
+| **採用初期** | 採用組織が POC〜本番初期投入する段階で完成すべき範囲 | tier1 全 Pod ハンドラ / Helm chart / Argo CD ApplicationSet |
+| **採用後の運用拡大時** | 複数チーム導入・マルチクラスタ化フェーズで導入される拡張 | OpenTofu / マルチクラスタフェデレーション / 高度な observability |
+
+本ファイルが扱うマチュリティの 3 ランクは以下の通り。
+
+| ランク | 意味 |
+|---|---|
+| **同梱済** | 実コードが存在し、ビルド・起動・テストが走る状態 |
+| **雛形あり** | ディレクトリ構造・主要ファイル・README は存在するが、ロジック実装は未完または最小骨格 |
+| **設計のみ** | docs に詳細設計があるが、対応する実装側ディレクトリは空または `.gitkeep` のみ |
+
+## 領域別マチュリティ表
+
+### tier1（公開 12 API + Dapr ファサード + Rust コア）
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `src/contracts/tier1/` proto 12 サービス | 12 API（state / pubsub / serviceinvoke / secrets / binding / workflow / log / telemetry / decision / audit / feature / pii） | **同梱済** | 14 proto / 47 RPC（公開 43 + health 2 + admin 2）配置済。`buf lint` / `buf format` 通過、4 SDK 再生成済。共通型は `common/v1/common.proto`（TenantContext / ErrorDetail / K1s0ErrorCategory）に集約 |
+| `src/contracts/internal/` proto | tier1 内部 gRPC（Go ↔ Rust core、ADR-TIER1-002 / ADR-TIER1-003） | **同梱済** | 4 proto / 3 service / 8 RPC 配置済（DS-SW-IIF-004〜029）。`buf generate --template buf.gen.internal.yaml` で Go と Rust に再生成 |
+| `src/tier1/go/cmd/{state,secret,workflow}/` | Go 側 3 Pod（DS-SW-COMP-005/006/010） | **雛形あり** | gRPC server bootstrap + 全 7 公開 API handler 登録完了（t1-state: 5 / t1-secret: 1 / t1-workflow: 1）。各 RPC は `internal/adapter/dapr/` 経由で `codes.Unimplemented` を返す |
+| `src/tier1/go/internal/common/` | 共通 runtime（gRPC bootstrap / config / retry / timeout） | **同梱済** | runtime / config / retry / timeout の 4 ユーティリティとテストが存在 |
+| `src/tier1/go/internal/otel/` | OTel 初期化 | **雛形あり** | 1 ファイルの最小骨格 |
+| `src/tier1/rust/crates/{decision, audit, pii}` | Rust 側 3 Pod（DS-SW-COMP-008/007/009） | **雛形あり** | 3 crate を配置。tonic server を :50001 で起動し公開 Service trait を登録、graceful shutdown 対応。全 RPC は Status::unimplemented |
+| `src/tier1/rust/crates/{common, otel-util, policy, proto, proto-gen}` | 共通 crate / proto stub | **雛形あり** | proto-gen crate 配置済、common / otel-util / policy / proto は `workspace.exclude` に置き plan 04-08 で順次合流予定 |
+| Dockerfile（distroless / nonroot / multi-stage） | 3 Pod 各 1 Dockerfile | **同梱済** | `Dockerfile.{state,secret,workflow}` は完成 |
+
+### contracts と SDK 生成
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `buf.gen.yaml` | 4 言語生成設定 | **同梱済** | tier1 公開と internal の 2 module 構成 |
+| `src/sdk/go/generated/` | Go gRPC stub | **同梱済** | 14 proto 分の正式 RPC 群を生成済 |
+| `src/sdk/dotnet/generated/` | .NET stub | **同梱済** | 14 proto 分を生成済 |
+| `src/sdk/rust/generated/` | Rust prost / tonic stub | **同梱済** | 14 proto 分を生成済 |
+| `src/sdk/typescript/generated/` | TS protobuf-es / connect-es stub | **同梱済** | 14 proto 分を生成済 |
+| 高水準 SDK（`k1s0.State.Save(...)` 等の動詞統一） | docs 規定の 4 言語動詞 | **同梱済**（14 service 全件） | 4 言語すべてに Client + 動詞統一 facade を 14 service 全件（公開 12 + Admin 2）で実装。Stream RPC（InvokeStream / PubSub.Subscribe）も 4 言語で同梱 |
+
+### tier2（C# / Go ドメイン共通）
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `src/tier2/templates/` + `src/tier3/templates/` | k1s0-scaffold が参照する Backstage Software Template v1beta3（IMP-CODEGEN-SCF-031〜034） | **同梱済** | 4 テンプレ配置済 |
+| `src/tier2/dotnet/services/{ApprovalFlow, InvoiceGenerator, TaxCalculator}` | tier2 完動例 | **同梱済** | 3 サービス DDD レイヤード（Domain / Application / Infrastructure / Api）+ xUnit ドメイン単体 + ArchitectureTests（NetArchTest）+ Dockerfile + catalog-info |
+| `src/tier2/go/services/{notification-hub, stock-reconciler}` | tier2 Go 完動例 | **同梱済** | 2 サービス cmd + internal/{api,config}/ + Dockerfile + catalog-info |
+
+### tier3（Web / Native / BFF / Legacy）
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `src/tier3/web/apps/{portal, admin, docs-site}` | React + Vite + pnpm | **同梱済** | 3 SPA（main.tsx / App.tsx / pages 2 件 / vitest 単体）+ Dockerfile（nginx + SPA fallback）+ catalog-info |
+| `src/tier3/web/packages/{ui, api-client, i18n, config}` | 共通パッケージ | **同梱済** | 4 package（ui: Button/Card/Spinner、api-client、i18n: ja/en、config）+ vitest 単体テスト |
+| `src/tier3/bff/cmd/{portal-bff, admin-bff}` | Go BFF | **同梱済** | 2 BFF cmd + GraphQL（schema.graphql）+ REST + auth/middleware + k1s0client + shared/{errors,otel} + Dockerfile.{portal,admin} |
+| `src/tier3/native/apps/{Hub, Admin}` | .NET MAUI | **同梱済** | 2 アプリ MAUI（App.xaml + AppShell + Pages + ViewModels + Services + Platforms/{Android,iOS}）+ shared/K1s0.Native.Shared + Native.sln |
+| `src/tier3/legacy-wrap/sidecars/K1s0.Legacy.Sidecar` | .NET Framework サイドカー | **同梱済** | ASP.NET Web API サイドカー（Global.asax + WebApiConfig + DaprConfig + K1s0BridgeController + DaprClientAdapter + StateValue + Web.config + packages.config + Dockerfile.windows）+ migration-guide 3 ステップ |
+
+### platform（CLI / Backstage プラグイン / Analyzer）
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `src/platform/scaffold/` | k1s0-scaffold CLI（Rust 実装、IMP-CODEGEN-SCF-030） | **同梱済** | Rust crate（edition 2024）+ 5 ソース（main.rs / lib.rs / template.rs / engine.rs / error.rs）+ README |
+| `src/platform/analyzer/` | .NET 依存方向 Roslyn Analyzer（IMP-DIR-ROOT-002）| **同梱済** | 4 診断 ID（K1S0DEPDIR0001〜0004）すべて Severity=Error。3 csproj + xUnit Tests + sln |
+| `src/platform/backstage-plugins/` | Backstage 開発者ポータル plugin（ADR-DEVEX-002） | **雛形あり** | 2 plugin（k1s0-catalog / k1s0-scaffolder）の skeleton |
+
+### infra（k8s / mesh / data / observability / security）
+
+| 領域 | docs 規定（リリース必須） | 実装ランク | 備考 |
+|---|---|---|---|
+| `infra/k8s/{bootstrap, namespaces, networking, storage}` | kubeadm HA + Calico/MetalLB | **雛形あり** | bootstrap: Cluster API + KubeadmControlPlane HA 3。namespaces: 17 layer に Pod Security Standards label + Istio Ambient ラベル。networking: Calico VXLAN + MetalLB。storage: 4 種 StorageClass |
+| `infra/mesh/istio-ambient/` | ADR-0001 / ADR-MIG-002 | **雛形あり** | profile ambient + istiod HA 3 replica + HPA + OTel tracing 連携 + ztunnel 設定 + mTLS STRICT |
+| `infra/mesh/envoy-gateway/` | ADR-CNCF-004 / IMP-DIR-INFRA-073 | **雛形あり** | Envoy Gateway controller HA 3 + GatewayClass + Gateway（public/internal）+ HTTPRoute（tier1-api / tier3-web / redirect）+ OTel tracing + Prometheus ServiceMonitor |
+| `infra/dapr/control-plane/` | Dapr operator | **雛形あり** | HA 全 control-plane component（operator/placement/sentry/sidecar-injector/scheduler）3 replica + mTLS + Prometheus + Raft consensus |
+| `infra/dapr/components/` + `infra/dapr/subscriptions/` | Dapr Component CRD（IMP-DIR-INFRA-074） | **雛形あり** | 7 Component（state/postgres / state/redis-cache / pubsub/kafka / secrets/vault / binding/s3-inbound / binding/smtp-outbound / configuration/default）+ 2 Subscription（audit-pii / feature） |
+| `infra/data/{cloudnativepg, kafka, minio, valkey}` | ADR-DATA-001/002/003/004 | **雛形あり** | 4 backend を production-grade defaults（HA / 監視 / バックアップ）で正規化済 |
+| `infra/security/{cert-manager, keycloak, openbao, spire, kyverno}` | ADR-SEC-001/002/003 / ADR-POL-001 | **雛形あり** | 5 component すべて HA 3 + 認証統合 + ServiceMonitor |
+| `infra/observability/{loki, tempo, mimir, grafana, otel-collector, pyroscope}` | ADR-OBS-001/002 | **雛形あり** | LGTM 6 component を production-grade で正規化済 |
+| `infra/scaling/keda/` | KEDA | **雛形あり** | operator HA 2 + metrics-apiserver 2 + admission webhook + ServiceMonitor |
+| `infra/feature-management/flagd/` | ADR-FM-001 | **雛形あり** | flagd HA 3 replica + ConfigMap baseline flag + Service + ServiceMonitor |
+| `infra/environments/{dev, staging, prod}` | 環境別 overlay（IMP-DIR-INFRA-078） | **雛形あり** | 3 環境 overlay（kustomization + patches + values + secrets/.gitkeep）+ README |
+
+### deploy（GitOps / Helm / Kustomize / OpenTofu）
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `deploy/README.md` | GitOps 配信定義の入口（IMP-DIR-COMM-110） | **同梱済** | deploy 配下の構造・Sync Wave・初期化手順を明記 |
+| `deploy/apps/app-of-apps.yaml` | App-of-Apps ルート（IMP-DIR-OPS-092） | **同梱済** | k1s0-platform AppProject 所属の Argo CD ルート Application |
+| `deploy/apps/application-sets/{infra,ops,tier1-facade,tier1-rust-service,tier2-dotnet-service,tier2-go-service,tier3-bff,tier3-web-app}.yaml` | カテゴリ別 ApplicationSet | **同梱済** | 8 ApplicationSet 配置完了。infra（Wave -10、list-generator）/ ops（Wave 40〜45）/ 6 サービス系（Wave 10〜30、image-updater annotation 付き） |
+| `deploy/apps/projects/{k1s0-platform,k1s0-tier1,k1s0-tier2,k1s0-tier3,rbac}.yaml` | AppProject + RBAC | **同梱済** | 4 AppProject + Argo CD グローバル RBAC ConfigMap（OIDC 連携） |
+| `deploy/charts/{tier1-facade, tier1-rust-service, tier2-go-service, tier2-dotnet-service, tier3-bff, tier3-web-app}` | Helm chart | **雛形あり** | 6 chart 全て配置完了。`helm lint` 通過、`helm template` 描画 OK |
+| `deploy/rollouts/canary-strategies/` | Argo Rollouts canary 戦略 | **雛形あり** | canary 25→50→100% の 3 段階戦略テンプレート |
+| `deploy/rollouts/analysis/` | 共通 ClusterAnalysisTemplate 5 本（IMP-REL-AT-040〜049） | **同梱済** | at-common-{error-rate,latency-p99,cpu,dependency-down,error-budget-burn}.yaml の 5 本（baseline 2σ / SLO 連動 / CPU 80% / 依存断短絡 / EB burn 2x）+ README |
+| `deploy/rollouts/analysis-templates/` | サービス固有 AnalysisTemplate 例 | **雛形あり** | error-rate.yaml / latency-p99.yaml の 2 例 |
+| `deploy/kustomize/{base, overlays/*}` | Kustomize | **雛形あり** | base + overlays/{dev,staging,prod}/ に 6 chart × 3 環境 = 18 values overlay |
+| `deploy/opentofu/{environments, modules}` | OpenTofu（採用後の運用拡大時） | **設計のみ** | `.gitkeep` のみ（採用後の運用拡大時 で展開、現段階では意図的に空） |
+| `deploy/image-updater/` | Argo CD Image Updater | **雛形あり** | argocd-image-updater Helm values + registries.conf ConfigMap + application-annotations.md |
+
+### tools / tests / examples
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `tools/local-stack/` | kind ベース本番再現スタック（IMP-DEV-POL-006） | **同梱済** | up.sh / down.sh / status.sh / kind-cluster.yaml / 17 レイヤ namespace yaml |
+| `tools/local-stack/manifests/{20..95}_*/` | 各レイヤの Helm values / Kustomize | **同梱済** | 17 レイヤ全てに values.yaml または manifest.yaml 配置済 |
+| `tools/devcontainer/` | 10 役 Dev Container プロファイル | **雛形あり** | postCreate.sh / doctor.sh / README は存在 |
+| `tools/sparse/` | sparse-checkout 10 役 cone 定義 | **雛形あり** | checkout-role.sh / verify.sh / README は存在 |
+| `tools/codegen/` | buf / openapi / grpc-docs 生成ラッパ | **同梱済** | 3 ラッパ script（buf/run.sh / openapi/run.sh / grpc-docs/run.sh） |
+| `tools/git-hooks/` | 自作 pre-commit hook | **同梱済** | japanese-header-guard.py / file-length-guard.py / drawio-svg-staleness.sh / link-check-wrapper.py |
+| `tools/_link_check.py` / `_link_fix.py` / `_export_svg.py` | docs 横断ツール | **同梱済** | docs リンク検査・drawio SVG export |
+| `tools/ci/go-dep-check/` + `tools/ci/rust-dep-check/` | 依存方向 linter（IMP-DIR-ROOT-002） | **同梱済** | Go / Rust 両側に独立 go.mod、`tier3 → tier2 → sdk → tier1` 一方向ルールを `import` / `path` 依存レベルで強制 |
+| `tests/` | e2e / contract / integration / fuzz / golden / fixtures | **雛形あり** | 6 カテゴリすべてに README + 動作可能な最小骨格 + CI hook 連携の入口 |
+| `examples/` | Golden Path 7 プロジェクト | **雛形あり** | 7 種すべてが build 可能な完動例。各 example に Dockerfile + catalog-info.yaml + 週次 E2E workflow |
+
+### ルート README 群（ドキュメント近接配置方針 / IMP-DIR-COMM-110）
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `src/README.md` | src 配下の入口 | **同梱済** | 配置構造・依存方向・コーディング規約・サブ設計リンク |
+| `src/contracts/README.md` | contracts の入口 | **同梱済** | 公開 12 API + 内部 gRPC 一覧、生成パス、buf ゲート |
+| `src/tier1/README.md` | tier1 の入口 | **同梱済** | 6 Pod 構成（DS-SW-COMP-005〜010）、ローカル起動手順 |
+| `src/tier2/README.md` | tier2 の入口 | **同梱済** | DDD レイヤ構造、言語選択指針、tier1 SDK 使用例 |
+| `src/tier3/README.md` | tier3 の入口 | **同梱済** | web / bff / native / legacy-wrap 配置、BFF パターン、k1s0.io annotation |
+| `src/platform/README.md` | platform の入口 | **同梱済** | scaffold CLI / analyzer / Backstage plugins |
+| `infra/README.md` | infra の入口 | **同梱済** | k8s / mesh / dapr / data / security / observability / scaling / feature-management / environments の俯瞰 |
+| `deploy/README.md` | deploy の入口 | **同梱済** | apps / charts / kustomize / rollouts / opentofu の俯瞰、Sync Wave 設計、Argo CD 初期化手順 |
+| `ops/README.md` | ops の入口 | **同梱済** | runbooks / chaos / dr / oncall / load の俯瞰、Runbook 5 段構成 |
+| `tools/README.md` | tools の入口 | **同梱済** | local-stack / devcontainer / codegen / sparse / git-hooks / ci の俯瞰、CI ゲート連携 |
+| `tests/README.md` | tests の入口 | **同梱済** | （既存） |
+| `examples/README.md` | examples の入口 | **同梱済** | （既存） |
+
+### CI / CD / GitOps
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `.github/workflows/pr.yml` | path-filter で 11 軸検出 + reusable workflow + ci-overall 集約 | **同梱済** | path-filter / reusable 4 本 / commitlint まで構成済 |
+| `.github/workflows/_reusable-{build,test,lint,precommit,push}.yml` | 言語別 reusable workflow | **同梱済** | 4 言語分岐 + SBOM(syft) 生成設計済 |
+| `.github/workflows/labels-sync.yml` / `renovate.yml` | リポジトリ運用 | **同梱済** | |
+| `.github/CODEOWNERS` / `labels.yml` / `repo-settings.md` | リポジトリ設定の正典化 | **同梱済** | |
+
+### docs / ADR
+
+| 領域 | docs 規定 | 実装ランク | 備考 |
+|---|---|---|---|
+| `docs/01_企画/` | 採用検討向け企画資料 | **同梱済** | |
+| `docs/02_構想設計/adr/` | 36 ADR | **同梱済** | 全 ADR 1 行索引 + 詳細索引の二重管理 |
+| `docs/02_構想設計/{01_アーキテクチャ, 02_tier1設計, 03_技術選定, 04_CICDと配信, 05_法務とコンプライアンス}` | 構想設計 | **同梱済** | |
+| `docs/03_要件定義/` | IPA 共通フレーム 2013 準拠 10 カテゴリ | **同梱済** | FR-T1 / NFR / BR / OR / DX / BC / RISK 体系 |
+| `docs/04_概要設計/` | DS-* 12 カテゴリ | **同梱済** | DS-SYS / DS-SW / DS-CF / DS-CTRL / DS-NFR / DS-OPS / DS-MIG / DS-DEVX / DS-BUS |
+| `docs/05_実装/` | IMP-* 13 章 | **同梱済** | IMP-DIR / IMP-BUILD / IMP-CODEGEN / IMP-CI / IMP-DEP / IMP-DEV / IMP-OBS / IMP-REL / IMP-SUP / IMP-SEC / IMP-POL / IMP-DX / IMP-TRACE |
+| `docs/40_運用ライフサイクル/` | Runbook（タイプ C 5 段構成） | **同梱済** | |
+| `docs/90_knowledge/` | 技術学習資料 | **同梱済** | |
+| `docs/INDEX.md` | 階層ナビゲーション索引 | **同梱済** | |
+
+## 「docs から逸脱しない」ことの保証
+
+本リポジトリの実装作業は、以下のメカニズムで docs 正典との整合性を保つ。
+
+1. **ADR が先行**: 構造を変える PR は `docs/02_構想設計/adr/` に新 ADR を起票してから着手する（CONTRIBUTING.md 規定）
+2. **ID 体系**: 要件 ID（FR-T1-* / NFR-* / BR-* / etc.）と設計 ID（DS-* / IMP-*）は実装側コミットメッセージにも追跡される（IMP-TRACE-*）
+3. **トレーサビリティ索引**: `docs/03_要件定義/80_トレーサビリティ/` と `docs/04_概要設計/80_トレーサビリティ/` で要件 → 設計 → ADR の対応が網羅される
+4. **CI ゲート**: `buf lint` / `buf breaking` / 内製 analyzer / pre-commit が逸脱を物理的に遮断する
+
+## 採用検討者へのガイダンス
+
+- **「docs を信じて全部動く」前提では採用しない**こと。本ファイルの「同梱済」のみを動作前提として評価してほしい
+- POC 用途では `tools/local-stack/up.sh --role docs-writer`（最小構成）または `--role tier1-rust-dev`（tier1 検証構成）から始めることを推奨する
+- 業務適用には「採用初期」段階の実装完了が必要。tier1 全 Pod ハンドラ・Helm chart 全種・examples 完動 4 種が完成してから本番投入を検討すること
+- 実装が進むに従い本ファイルは更新される。最新版は main ブランチの本ファイルを参照
+
+## 残存「設計のみ」一覧（リリース時点 v0 対象）
+
+リリース時点（v0.x）では以下のみが「設計のみ」として残る。これらはすべて採用後の運用拡大時段階の対象で、
+リリース時点で同梱しないことが docs / ADR 上で確定済み。
+
+| 残存項目 | 段階 | 理由 |
+|---|---|---|
+| `deploy/opentofu/{environments,modules}/` | 採用後の運用拡大時 | OpenTofu はマルチクラスタ展開時に Terraform 移行先として導入予定。リリース時点で同梱すると未使用コードが採用検討者に誤認される |
+| `deploy/rollouts/experiments/` | 採用後の運用拡大時 | Argo Rollouts の Experiment CRD は A/B テスト等の高度な配信機能で、採用初期では使わない |
+
+その他のすべての「リリース時点必須」項目は **同梱済 / 雛形あり** のいずれかに到達している。
+雛形ありの項目は採用初期段階で内容実装が進む。
+
+## 次の段階で進めるべき作業（採用初期へのロードマップ）
+
+リリース時点（v0.x）から採用初期段階へ進むために、以下を**docs を逸脱せず**実装する必要がある。
+順序は依存方向（contracts → SDK → tier1 → tier2/tier3）と外部評価の費用対効果を考慮した推奨順。
+
+### 1〜8. 完了項目（リリース時点で達成）
+
+contracts / SDK / tier1 / Rust 3 Pod / infra / deploy / examples / SDK 高水準 facade の 8 項目は
+リリース時点で完了済み（詳細は本ファイル「領域別マチュリティ表」参照）。
+
+### 9. tier1 ハンドラの実体化（採用初期）
+
+各 RPC の `codes.Unimplemented` を Dapr SDK / OpenBao / Temporal 結線に置換する作業。
+依存先（CNPG / Kafka / Valkey / OpenBao / Temporal）の Helm 適用と並行で進める。
+
+### 10. infra Operator 実体化（採用初期）
+
+雛形ありの component を採用組織の k8s クラスタに対して実適用し、`helm install` / `kubectl apply` の
+動作確認と SOPS 暗号化 secret 配置を完了する。
+
+### 11. Backstage 実機統合（採用初期）
+
+`src/platform/backstage-plugins/` を採用組織の Backstage バージョンに合わせて
+`@backstage/core-plugin-api` 等から import 結線する作業。
+
+### 12. examples ユニット / 統合テスト追加（採用初期）
+
+各 example に対する unit / integration test の雛形を埋める作業。
+
+各タスクは完成のたびに本 SHIP_STATUS.md のマチュリティ表を更新する運用とする。

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,70 @@
+# infra — k8s クラスタ素構成（Operator / data backend / mesh / observability / security）
+
+ADR-DIR-002（infra 分離）に従い、**マニフェスト形式のインフラ宣言** のみを集約する。
+GitOps 配信定義（ApplicationSet 等）は [`deploy/`](../deploy/) に分離され、本ディレクトリは
+「クラスタに何が乗っているか」の宣言だけを持つ。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/50_infraレイアウト/`](../docs/05_実装/00_ディレクトリ設計/50_infraレイアウト/)。
+
+## 配置
+
+```text
+infra/
+├── k8s/
+│   ├── bootstrap/                          # Cluster API + KubeadmControlPlane HA 3 / kubeadm-init 代替
+│   ├── namespaces/                         # 17 layer namespace + Pod Security Standards label + Istio Ambient mode label
+│   ├── networking/                         # Calico VXLAN + MetalLB（IPAddressPool は環境別 overlay）
+│   └── storage/                            # 4 種 StorageClass（default / high-iops / shared / backup）
+├── mesh/
+│   ├── istio-ambient/                      # CNI + ztunnel + istiod HA 3、PeerAuthentication STRICT
+│   └── envoy-gateway/                      # Gateway API 標準準拠の南北 ingress
+├── dapr/
+│   ├── control-plane/                      # operator / placement / sentry / sidecar-injector / scheduler（HA 3）
+│   ├── components/                         # Dapr Component CRD（state / pubsub / secrets / binding / configuration）
+│   └── subscriptions/                      # Dapr Subscription CRD（audit-pii / feature 配信）
+├── data/                                   # ADR-DATA-001/002/003/004
+│   ├── cloudnativepg/                      # 3 instance HA + WAL アーカイブ + PodMonitor
+│   ├── kafka/                              # Strimzi KRaft 3 broker + TLS mTLS + Cruise Control
+│   ├── minio/                              # distributed mode 4 replica + erasure coding
+│   └── valkey/                             # replication + Sentinel + 認証有効
+├── security/                               # ADR-SEC-001/002/003 / ADR-POL-001
+│   ├── cert-manager/                       # HA 3 + Let's Encrypt + 内部 CA ClusterIssuer
+│   ├── keycloak/                           # HA 3 + Infinispan + 外部 CNPG + production mode
+│   ├── openbao/                            # HA 3 + Raft integrated storage + Vault Agent Injector
+│   ├── spire/                              # server HA 3 + 外部 CNPG + cert-manager upstream + CSI driver
+│   └── kyverno/                            # admission HA 3 + 4 baseline ClusterPolicy
+├── observability/                          # ADR-OBS-001/002（LGTM スタック）
+│   ├── grafana/                            # HA 2 + Keycloak OIDC + sidecar pickup
+│   ├── loki/                               # SimpleScalable + S3
+│   ├── tempo/                              # distributed + S3 + memcached
+│   ├── mimir/                              # distributed + S3 + zoneAwareReplication
+│   ├── pyroscope/                          # micro-services + S3
+│   └── otel-collector/                     # agent DaemonSet + gateway Deployment 3 replica
+├── scaling/keda/                           # operator HA 2 + metrics-apiserver + admission webhook
+├── feature-management/flagd/               # HA 3 + ConfigMap baseline flag + ServiceMonitor
+└── environments/                           # 環境別 overlay（IMP-DIR-INFRA-078）
+    ├── dev/                                # CNPG 3→1 / Kafka 100Gi→5Gi / 軽量 LGTM
+    ├── staging/                            # CNPG 3→2 / Kafka 100Gi→50Gi
+    └── prod/                               # 空（base がそのまま prod）
+```
+
+## マニフェストの編成原則
+
+- **Helm values と Kustomize patch を分離**: 各 component 配下に `values.yaml`（Helm 用）と
+  `<component>-cluster.yaml`（CR 宣言）を併置。環境別差分は `infra/environments/<env>/values/<component>/values.yaml` で overlay。
+- **Operator と CR の Sync Wave 分離**: Operator は Wave -10、CR 宣言は Wave -5、data backend は Wave 0。
+  Argo CD Sync Wave で起動順序を物理的に強制（[`deploy/apps/`](../deploy/apps/) 参照）。
+- **AGPL の取り扱い**: MinIO ほか AGPL 依存 OSS は infra 内部でのみ稼働し、ネットワーク越しに改変版を
+  ユーザに提供しない。法務判定は [`docs/02_構想設計/05_法務とコンプライアンス/`](../docs/02_構想設計/05_法務とコンプライアンス/)。
+
+## 採用検討段階のローカル再現
+
+`tools/local-stack/up.sh` で 17 layer namespace + 主要 component の最小構成を kind クラスタ上に立ち上げられる
+（[`tools/local-stack/`](../tools/local-stack/) 参照）。
+
+## 関連設計
+
+- [ADR-DIR-002](../docs/02_構想設計/adr/ADR-DIR-002-infra-separation.md) — infra 分離
+- [ADR-MIG-002](../docs/02_構想設計/adr/ADR-MIG-002-istio-ambient-migration.md) — Ambient Mesh
+- [ADR-DATA-001〜004](../docs/02_構想設計/adr/) — data backend 選定
+- [ADR-SEC-001/002/003](../docs/02_構想設計/adr/) — Keycloak / OpenBao / SPIRE
+- [ADR-OBS-001/002](../docs/02_構想設計/adr/) — Grafana LGTM

--- a/infra/mesh/envoy-gateway/README.md
+++ b/infra/mesh/envoy-gateway/README.md
@@ -1,0 +1,74 @@
+# infra/mesh/envoy-gateway — Envoy Gateway（南北 ingress）
+
+ADR-CNCF-004（Envoy Gateway 選定）/ ADR-DIR-002（infra 分離）/ IMP-DIR-INFRA-073（サービスメッシュ配置）に従い、
+クラスタ外部からの L7 ingress を Gateway API 標準準拠で運用する。Istio Ambient（東西 mTLS）と
+責務を分離し、Envoy Gateway は南北のみを担う。
+
+## なぜ Envoy Gateway か
+
+- **Gateway API 標準準拠**: Kubernetes 標準の `gateway.networking.k8s.io/v1` を採用するため、Ingress 層の将来移行コストが低い。
+- **Istio Ingress Gateway を使わない**: Ambient mode は east-west（pod ↔ pod）に特化する設計で、
+  ingress は別 component に分離した方が運用上の責務が明瞭。
+- **拡張性**: EnvoyPatchPolicy / Backend / SecurityPolicy 等の Envoy Gateway 固有 CRD で
+  L7 ポリシーを宣言的に追加できる。
+
+## ファイル構成
+
+| ファイル | 内容 |
+|---|---|
+| `values.yaml` | Envoy Gateway controller の Helm values（HA 3 replica + OTel tracing 連携 + Prometheus メトリクス） |
+| `gatewayclass-envoy.yaml` | GatewayClass `envoy-gateway-class` 定義（全 Gateway の親） |
+| `gateway-public.yaml` | インターネット公開用 Gateway（`api.k1s0.internal` / `app.k1s0.internal`、MetalLB public プール経由） |
+| `gateway-internal.yaml` | VPN / Bastion 内部公開用 Gateway（`ops.k1s0.internal` / `portal.k1s0.internal`、MetalLB internal プール経由） |
+| `httproute/tier1-api.yaml` | tier1 公開 12 API への path 単位ルーティング（`/api/v1/{state,pubsub,...}` → t1-state / t1-secret / t1-workflow / Rust 3 Pod） |
+| `httproute/tier3-web.yaml` | tier3 Web SPA / BFF へのルーティング（`/admin` `/docs` `/` + `/api/portal` `/api/admin`） |
+| `httproute/redirect-http-to-https.yaml` | HTTP → HTTPS の 301 恒久リダイレクト |
+
+## デプロイ
+
+```sh
+# Envoy Gateway controller の install（Argo CD ApplicationSet からも可）
+helm install eg oci://docker.io/envoyproxy/gateway-helm \
+  --namespace envoy-gateway-system --create-namespace \
+  --version v1.2.0 -f infra/mesh/envoy-gateway/values.yaml
+
+# GatewayClass / Gateway / HTTPRoute を順に apply
+kubectl apply -f infra/mesh/envoy-gateway/gatewayclass-envoy.yaml
+kubectl apply -f infra/mesh/envoy-gateway/gateway-public.yaml
+kubectl apply -f infra/mesh/envoy-gateway/gateway-internal.yaml
+kubectl apply -f infra/mesh/envoy-gateway/httproute/
+```
+
+prod では Argo CD ApplicationSet `tier-mesh`（plan 06-XX）から本ディレクトリを kustomize で適用する。
+
+## Istio Ambient との責務分離
+
+| レイヤ | 担当 component | 通信種別 | 暗号化 |
+|---|---|---|---|
+| 南北（外部 ↔ クラスタ） | **Envoy Gateway**（本ディレクトリ） | HTTPS / gRPC | TLS 終端（cert-manager） |
+| 東西（pod ↔ pod） | **Istio Ambient**（`infra/mesh/istio-ambient/`） | L4 / L7 | ztunnel mTLS STRICT |
+| 東西の L7 認可 | Istio Waypoint Proxy | L7 | （ztunnel 上） |
+
+南北リクエストの典型フロー:
+
+1. クライアント → MetalLB external IP → Envoy Gateway controller（TLS 終端、HTTPRoute 評価）
+2. Envoy Gateway → backend Service（pod IP）
+3. ztunnel が pod-to-pod 通信を mTLS で再暗号化
+4. backend pod の Dapr sidecar / アプリ コンテナへ到達
+
+## ローカル開発との差分
+
+| 観点 | dev（`tools/local-stack/manifests/30-envoy-gateway/`、暫定） | prod（本ディレクトリ） |
+|---|---|---|
+| Envoy Gateway controller replica | 1 | 3 + Pod AntiAffinity |
+| ホスト名 | `*.k1s0.local`（/etc/hosts） | `*.k1s0.internal`（社内 DNS） |
+| TLS | self-signed | cert-manager（letsencrypt-prod / internal-ca） |
+| OTel tracing | （無効） | OTel Collector gateway へ送信、sampling 100% |
+| Prometheus | （無効） | ServiceMonitor 有効、port 19001 |
+
+## 関連設計
+
+- [ADR-CNCF-004](../../../docs/02_構想設計/adr/) — Envoy Gateway 選定
+- [ADR-MIG-002](../../../docs/02_構想設計/adr/ADR-MIG-002-istio-ambient-migration.md) — sidecar → ambient 移行
+- [ADR-OBS-002](../../../docs/02_構想設計/adr/ADR-OBS-002-otel-pipeline.md) — Envoy Gateway から OTel exporter
+- [IMP-DIR-INFRA-073](../../../docs/05_実装/00_ディレクトリ設計/50_infraレイアウト/03_サービスメッシュ配置.md)

--- a/infra/mesh/envoy-gateway/gateway-internal.yaml
+++ b/infra/mesh/envoy-gateway/gateway-internal.yaml
@@ -1,0 +1,53 @@
+# 本ファイルは VPN / Bastion 内部公開用 Gateway。
+# 採用組織の VPN 内部 IP プールから露出し、運用ツール（Backstage / Grafana / Argo CD UI）への
+# アクセスを社内ネットワークに限定する。
+# 内部 CA（cert-manager の ClusterIssuer `internal-ca`）が発行する証明書で TLS 終端。
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: k1s0-gateway-internal
+  namespace: k1s0-mesh
+  annotations:
+    metallb.universe.tf/address-pool: internal-pool
+    cert-manager.io/cluster-issuer: internal-ca
+  labels:
+    k1s0.io/component: ingress
+    k1s0.io/exposure: internal
+spec:
+  gatewayClassName: envoy-gateway-class
+  listeners:
+    - name: https-ops
+      protocol: HTTPS
+      port: 443
+      hostname: ops.k1s0.internal
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: k1s0-internal-ops-cert
+            namespace: k1s0-mesh
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              k1s0.io/exposure: internal
+    - name: https-portal
+      protocol: HTTPS
+      port: 443
+      hostname: portal.k1s0.internal
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: k1s0-internal-portal-cert
+            namespace: k1s0-mesh
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              k1s0.io/component: developer-portal
+  infrastructure:
+    annotations:
+      service.beta.kubernetes.io/external-traffic: Local

--- a/infra/mesh/envoy-gateway/gateway-public.yaml
+++ b/infra/mesh/envoy-gateway/gateway-public.yaml
@@ -1,0 +1,61 @@
+# 本ファイルはインターネット公開用 Gateway（MetalLB の external IP で露出）。
+# ホスト名 `api.k1s0.internal` / `app.k1s0.internal` を受け、
+# `httproute/` 配下の HTTPRoute で tier1 API と tier3 Web に振り分ける。
+#
+# TLS: cert-manager が発行する Let's Encrypt 証明書を `tls.k1s0-public-cert` に保管し、
+# Gateway は本 Secret を参照して TLS 終端する（ADR-SEC-001）。
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: k1s0-gateway-public
+  namespace: k1s0-mesh
+  annotations:
+    metallb.universe.tf/address-pool: public-pool
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  labels:
+    k1s0.io/component: ingress
+    k1s0.io/exposure: public
+spec:
+  gatewayClassName: envoy-gateway-class
+  listeners:
+    - name: http-redirect
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-api
+      protocol: HTTPS
+      port: 443
+      hostname: api.k1s0.internal
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: k1s0-public-api-cert
+            namespace: k1s0-mesh
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              k1s0.io/tier: tier1
+    - name: https-app
+      protocol: HTTPS
+      port: 443
+      hostname: app.k1s0.internal
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: k1s0-public-app-cert
+            namespace: k1s0-mesh
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              k1s0.io/tier: tier3
+  infrastructure:
+    annotations:
+      service.beta.kubernetes.io/external-traffic: Local

--- a/infra/mesh/envoy-gateway/gatewayclass-envoy.yaml
+++ b/infra/mesh/envoy-gateway/gatewayclass-envoy.yaml
@@ -1,0 +1,15 @@
+# 本ファイルは Envoy Gateway の GatewayClass 定義。
+# Gateway API 標準（gateway.networking.k8s.io/v1）の `gatewayClassName` を提供し、
+# 各 Gateway リソースから本クラスを参照することで Envoy Gateway controller が
+# 該当 Gateway を実体化する。
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-gateway-class
+  labels:
+    app.kubernetes.io/name: envoy-gateway-class
+    app.kubernetes.io/managed-by: argocd
+    k1s0.io/component: ingress
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  description: "k1s0 共通の Envoy Gateway クラス（南北 ingress）"

--- a/infra/mesh/envoy-gateway/httproute/redirect-http-to-https.yaml
+++ b/infra/mesh/envoy-gateway/httproute/redirect-http-to-https.yaml
@@ -1,0 +1,22 @@
+# 本ファイルは HTTP → HTTPS への 301 redirect HTTPRoute。
+# Gateway listener `http-redirect`（port 80）に届く全リクエストを
+# 同一ホストの HTTPS（port 443）へ恒久リダイレクトする。
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-to-https
+  namespace: k1s0-mesh
+  labels:
+    k1s0.io/component: ingress
+spec:
+  parentRefs:
+    - name: k1s0-gateway-public
+      namespace: k1s0-mesh
+      sectionName: http-redirect
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+            port: 443

--- a/infra/mesh/envoy-gateway/httproute/tier1-api.yaml
+++ b/infra/mesh/envoy-gateway/httproute/tier1-api.yaml
@@ -1,0 +1,114 @@
+# 本ファイルは tier1 公開 12 API への HTTPRoute（path 単位ルーティング）。
+# `api.k1s0.internal` へ届いた `/api/v1/{state,pubsub,...}` を t1-state / t1-secret /
+# t1-workflow および Rust 側 3 Pod（decision / audit / pii）にバックエンド振り分けする。
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tier1-api
+  namespace: k1s0-tier1
+  labels:
+    k1s0.io/tier: tier1
+spec:
+  parentRefs:
+    - name: k1s0-gateway-public
+      namespace: k1s0-mesh
+      sectionName: https-api
+  hostnames:
+    - api.k1s0.internal
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/state
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/pubsub
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/serviceinvoke
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/binding
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/feature
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/log
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/telemetry
+      backendRefs:
+        - name: t1-state
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/secrets
+      backendRefs:
+        - name: t1-secret
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/workflow
+      backendRefs:
+        - name: t1-workflow
+          port: 50051
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/decision
+      backendRefs:
+        - name: t1-decision
+          port: 50001
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/audit
+      backendRefs:
+        - name: t1-audit
+          port: 50001
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/pii
+      backendRefs:
+        - name: t1-pii
+          port: 50001
+          weight: 100

--- a/infra/mesh/envoy-gateway/httproute/tier3-web.yaml
+++ b/infra/mesh/envoy-gateway/httproute/tier3-web.yaml
@@ -1,0 +1,70 @@
+# 本ファイルは tier3 Web（portal / admin / docs-site）への HTTPRoute。
+# `app.k1s0.internal` へ届いた `/{portal,admin,docs}` を web SPA に振り分ける。
+# `/api/` プレフィックスは BFF（portal-bff / admin-bff）にプロキシする。
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tier3-web
+  namespace: k1s0-tier3
+  labels:
+    k1s0.io/tier: tier3
+spec:
+  parentRefs:
+    - name: k1s0-gateway-public
+      namespace: k1s0-mesh
+      sectionName: https-app
+  hostnames:
+    - app.k1s0.internal
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/portal
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: portal-bff
+          port: 8080
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/admin
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: admin-bff
+          port: 8080
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /admin
+      backendRefs:
+        - name: tier3-admin-web
+          port: 80
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /docs
+      backendRefs:
+        - name: tier3-docs-site
+          port: 80
+          weight: 100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: tier3-portal-web
+          port: 80
+          weight: 100

--- a/infra/mesh/envoy-gateway/values.yaml
+++ b/infra/mesh/envoy-gateway/values.yaml
@@ -1,0 +1,94 @@
+# 本ファイルは Envoy Gateway（ADR-CNCF-004）の Helm values 設定。
+# Istio Ambient と並走する ingress 層を Gateway API 標準準拠で運用する。
+# helm install eg oci://docker.io/envoyproxy/gateway-helm --namespace envoy-gateway-system \
+#   --create-namespace --version v1.2.0 -f values.yaml
+#
+# Ambient（東西 mTLS）と Envoy Gateway（南北 ingress）の責務分離方針:
+#   - Ambient: pod ↔ pod の L4 mTLS と L7 認可（waypoint）
+#   - Envoy Gateway: クラスタ外部からの L7 ingress（Gateway API 経由）
+#
+# dev は tools/local-stack/manifests/30-istio-ambient/ に揃えず、Envoy Gateway も同一構成を採用。
+
+# Envoy Gateway controller の prod sizing
+deployment:
+  replicas: 3
+  envoyGateway:
+    image:
+      repository: docker.io/envoyproxy/gateway
+      tag: v1.2.0
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
+  pod:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: envoy-gateway
+              topologyKey: kubernetes.io/hostname
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "19001"
+
+# Envoy Gateway の admission webhook 設定
+config:
+  envoyGateway:
+    provider:
+      type: Kubernetes
+    gateway:
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    # OpenTelemetry トレーシングを Collector gateway へ送信
+    extensionApis:
+      enableEnvoyPatchPolicy: true
+      enableBackend: true
+    telemetry:
+      metrics:
+        prometheus:
+          disable: false
+        sinks:
+          - type: OpenTelemetry
+            openTelemetry:
+              host: otel-collector-gateway.observability.svc.cluster.local
+              port: 4317
+              protocol: grpc
+      tracing:
+        provider:
+          host: otel-collector-gateway.observability.svc.cluster.local
+          port: 4317
+          type: OpenTelemetry
+        samplingRate: 100
+      accessLog:
+        settings:
+          - format:
+              type: JSON
+              json:
+                start_time: "%START_TIME%"
+                method: "%REQ(:METHOD)%"
+                path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                protocol: "%PROTOCOL%"
+                response_code: "%RESPONSE_CODE%"
+                upstream_cluster: "%UPSTREAM_CLUSTER%"
+                trace_id: "%REQ(x-b3-traceid)%"
+            sinks:
+              - type: File
+                file:
+                  path: /dev/stdout
+
+# RBAC / ServiceAccount は chart のデフォルトに任せる
+serviceAccount:
+  create: true
+
+# Prometheus 連携
+metrics:
+  port: 19001
+  serviceMonitor:
+    enabled: true
+    namespace: envoy-gateway-system
+    interval: 30s

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,55 @@
+# ops — 運用領域（Runbook / Chaos / DR / Oncall / Load）
+
+ADR-DIR-001/002 と Runbook 設計（タイプ C: 検出 / 初動 / 復旧 / 原因調査 / 事後処理 5 段構成）に基づき、
+**運用ライフサイクルの実体ファイル** を集約する。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/05_ops配置_Runbook_Chaos_DR.md`](../docs/05_実装/00_ディレクトリ設計/60_operationレイアウト/05_ops配置_Runbook_Chaos_DR.md)。
+
+## 配置
+
+```text
+ops/
+├── runbooks/                                       # 5 段構成 Runbook（タイプ C）
+│   ├── daily/                                      # 日次運用（バックアップ確認 / 容量チェック）
+│   ├── weekly/                                     # 週次運用（fuzz nightly / chaos drill）
+│   ├── monthly/                                    # 月次運用（DR 演習 / 棚卸し）
+│   ├── incidents/                                  # インシデント対応 Runbook
+│   ├── secret-rotation.md                          # OpenBao 経由のキーローテ手順
+│   └── templates/                                  # Runbook 雛形
+├── chaos/                                          # LitmusChaos
+│   ├── experiments/                                # 個別実験定義
+│   ├── probes/                                     # SLO 連動 probe
+│   └── workflows/                                  # 連続実験ワークフロー
+├── dr/                                             # DR（Disaster Recovery）
+│   ├── drills/                                     # 半期 1 回の DR 演習記録
+│   ├── scenarios/                                  # 想定シナリオ集（cluster ロス / data loss）
+│   └── scripts/                                    # 復旧自動化スクリプト
+├── oncall/
+│   ├── rotation/                                   # PagerDuty 連動の当番表
+│   └── sops-key/                                   # SOPS 暗号鍵の運用手順（OpenBao 経由）
+├── load/
+│   ├── k6/                                         # k6 負荷テスト（NFR-B-PERF 連動）
+│   └── scenarios/                                  # 採用組織別シナリオ
+└── scripts/lib/                                    # 共通シェルライブラリ
+```
+
+## Runbook の 5 段構成（タイプ C）
+
+各 Runbook は以下を必ず含む。空セクションは認めない（`docs-postmortem` Skill と整合）:
+
+1. **検出（Detection）**: アラートトリガ / Grafana ダッシュボード / 異常パターン
+2. **初動（Triage）**: 5 分以内の暫定対応 / トラフィック切替 / scale up
+3. **復旧（Recovery）**: ロールバック / 切戻し / 完全復旧
+4. **原因調査（Root Cause）**: ログ / トレース / メトリクスの収集ポイント
+5. **事後処理（Post-mortem）**: ポストモーテム作成 / 再発防止アクション
+
+## 主要 Runbook（リリース時点 整備対象）
+
+FMEA で RPN ≥ 30 とされた 10 故障モードに対応する Runbook を **リリース時点までに整備** する
+（[docs/04_概要設計/55_運用ライフサイクル方式設計/06_FMEA分析方式.md](../docs/04_概要設計/55_運用ライフサイクル方式設計/06_FMEA分析方式.md)）。
+
+## 関連設計
+
+- [docs/04_概要設計/55_運用ライフサイクル方式設計/03_環境構成管理方式.md](../docs/04_概要設計/55_運用ライフサイクル方式設計/03_環境構成管理方式.md)
+- [docs/04_概要設計/55_運用ライフサイクル方式設計/06_FMEA分析方式.md](../docs/04_概要設計/55_運用ライフサイクル方式設計/06_FMEA分析方式.md)
+- [docs/04_概要設計/55_運用ライフサイクル方式設計/08_Runbook設計方式.md](../docs/04_概要設計/55_運用ライフサイクル方式設計/08_Runbook設計方式.md)
+- [docs/40_運用ライフサイクル/](../docs/40_運用ライフサイクル/) — Runbook 索引

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,53 @@
+# src — k1s0 ソースコード一次配置
+
+本ディレクトリは k1s0 全コード（contracts / tier1 / SDK / tier2 / tier3 / platform）を集約する。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/02_src配下の層別分割.md`](../docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/02_src配下の層別分割.md)。
+
+## 配置構造
+
+```text
+src/
+├── CLAUDE.md           # コーディング規約（日本語コメント / 500 行制限 / 言語別基本）
+├── contracts/          # *.proto — single source of truth（tier1 公開 12 API + 内部 gRPC）
+├── tier1/
+│   ├── go/             # Dapr Go SDK ファサード（3 Pod: state / secret / workflow）
+│   └── rust/           # ZEN Engine / 暗号 / 雛形 CLI（3 Pod: decision / audit / pii）
+├── sdk/                # contracts から自動生成（4 言語: dotnet / go / rust / typescript）
+├── tier2/              # ドメイン共通業務ロジック（C# / Go）
+├── tier3/              # Web（React + TS）/ Native（.NET MAUI）/ BFF（Go）/ Legacy wrap（.NET Framework）
+└── platform/           # scaffold CLI / dependency analyzer / Backstage plugins
+```
+
+## 依存方向（一方向のみ、逆向きは CI で遮断）
+
+```text
+tier3 → tier2 → (sdk ← contracts) → tier1 → infra
+```
+
+逆方向の参照は内製 analyzer（`src/platform/analyzer/`）と `tools/ci/{go,rust}-dep-check/` の二重で reject される。
+詳細は [`docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/05_依存方向ルール.md`](../docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/05_依存方向ルール.md)。
+
+## コーディング規約（必読）
+
+[`CLAUDE.md`](CLAUDE.md) を必ず参照すること。要点:
+
+- **日本語コメント必須**: 全コードファイルの先頭に日本語の説明コメント、各行の 1 行上にも日本語コメント
+- **1 ファイル 500 行以内**: 例外なし。`tools/git-hooks/file-length-guard.py` で機械的に強制
+- **tier1 内部のサービス間通信は Protobuf gRPC 必須**
+- **tier2 / tier3 から内部言語（Rust / Go）は不可視**: クライアントライブラリと gRPC エンドポイントのみ公開
+
+## サブディレクトリ別の詳細設計
+
+| ディレクトリ | 詳細設計 |
+|---|---|
+| `contracts/` | [docs/05_実装/00_ディレクトリ設計/30_共通契約レイアウト/](../docs/05_実装/00_ディレクトリ設計/30_共通契約レイアウト/) |
+| `tier1/` | [docs/05_実装/00_ディレクトリ設計/20_tier1レイアウト/](../docs/05_実装/00_ディレクトリ設計/20_tier1レイアウト/) |
+| `sdk/` | [docs/05_実装/00_ディレクトリ設計/30_共通契約レイアウト/](../docs/05_実装/00_ディレクトリ設計/30_共通契約レイアウト/) |
+| `tier2/` | [docs/05_実装/00_ディレクトリ設計/35_tier2レイアウト/](../docs/05_実装/00_ディレクトリ設計/35_tier2レイアウト/) |
+| `tier3/` | [docs/05_実装/00_ディレクトリ設計/40_tier3レイアウト/](../docs/05_実装/00_ディレクトリ設計/40_tier3レイアウト/) |
+| `platform/` | [docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/02_src配下の層別分割.md](../docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/02_src配下の層別分割.md) |
+
+## 実装マチュリティの開示
+
+採用検討者は [`docs/SHIP_STATUS.md`](../docs/SHIP_STATUS.md) を参照すること。docs（設計）が記述する全体像と
+実コードの実装率（同梱済 / 雛形あり / 設計のみ）を領域別に開示している。

--- a/src/contracts/README.md
+++ b/src/contracts/README.md
@@ -1,0 +1,71 @@
+# src/contracts — k1s0 single source of truth（Protobuf）
+
+本ディレクトリは tier1 公開 12 API と内部 gRPC を Protobuf で定義する。
+**契約は手書き、SDK は生成物**。`buf generate` で 4 言語 SDK（.NET / Go / Rust / TypeScript）を自動生成する。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/30_共通契約レイアウト/`](../../docs/05_実装/00_ディレクトリ設計/30_共通契約レイアウト/)。
+
+## 配置構造
+
+```text
+contracts/
+├── buf.yaml                          # 2 module 構成（tier1 / internal）
+├── buf.lock                          # 依存固定
+├── tier1/                            # 公開 12 API（tier2 / tier3 から見える）
+│   └── k1s0/tier1/<api>/v1/*.proto
+└── internal/                         # tier1 内部 gRPC（Go ↔ Rust core）
+    └── k1s0/internal/<comp>/v1/*.proto
+```
+
+## 公開 12 API（`tier1/k1s0/tier1/<api>/v1/`）
+
+| API | 主な動詞 | RPC 数 |
+|---|---|---|
+| `state` | Get / Save / Delete / GetBulk / SaveBulk | 5 |
+| `pubsub` | Publish / Subscribe（streaming）/ DeleteSubscription | 3 |
+| `serviceinvoke` | Invoke / InvokeStream（streaming） | 2 |
+| `secrets` | Get / GetBulk / Rotate | 3 |
+| `binding` | Invoke | 1 |
+| `workflow` | Start / Signal / Query / Cancel / Terminate / GetStatus | 6 |
+| `log` | Send（streaming）/ SendBatch | 2 |
+| `telemetry` | EmitMetric / EmitSpan | 2 |
+| `decision` | Evaluate / BatchEvaluate / RegisterRule / ListVersions / GetRule | 5 |
+| `audit` | Record / Query | 2 |
+| `pii` | Classify / Mask | 2 |
+| `feature` | EvaluateBoolean / String / Number / Object / Refresh / RegisterFlag / GetFlag / ListFlags | 7（公開）+ 3（admin） |
+| `health` | Check / Watch（streaming） | 2（gRPC 標準） |
+
+合計 43 RPC（health 除く）/ 47 RPC（health 含む）。共通型は `tier1/k1s0/tier1/common/v1/common.proto` に集約
+（`TenantContext` / `ErrorDetail` / `K1s0ErrorCategory`）。
+
+## 内部 gRPC（`internal/k1s0/internal/<comp>/v1/`）
+
+| パッケージ | 主題 | 設計 |
+|---|---|---|
+| `errors.v1` | `ErrorDetail` + 6 区分 `ErrorCategory` | DS-SW-IIF-004 |
+| `audit.v1.AuditService` | `AppendHash` / `VerifyChain`（Server Streaming） | DS-SW-IIF-005 |
+| `decision.v1.DecisionService` | `EvaluateDecision`（collect_trace 対応） | DS-SW-IIF-006 |
+| `pii.v1.PiiMaskService` | `MaskPii` / `MaskPiiBatch`（p99 < 3ms 目標） | DS-SW-IIF-007 |
+
+## 生成パス
+
+`buf generate` の出力先（docs 正典）:
+
+| 言語 | 出力先 |
+|---|---|
+| Go（公開） | `src/sdk/go/proto/v1/k1s0/tier1/<api>/v1/` |
+| Rust（公開） | `src/sdk/rust/crates/k1s0-sdk-proto/src/gen/v1/` |
+| TypeScript（公開） | `src/sdk/typescript/src/proto/k1s0/tier1/<api>/v1/` |
+| .NET（公開） | `src/sdk/dotnet/src/K1s0.Sdk.Proto/Generated/` |
+| Go（内部） | `src/tier1/go/internal/proto/v1/` |
+| Rust（内部） | `src/tier1/rust/crates/proto-gen/src/` |
+
+## ゲート
+
+- `buf lint` / `buf format` / `buf breaking`（PR で 3 種すべて通過必須）
+- IDL 命名規約と STANDARD lint の衝突箇所は `buf.yaml` の `lint.except` で除外（IDL 正典を優先）
+
+## 関連設計
+
+- [ADR-TIER1-002](../../docs/02_構想設計/adr/ADR-TIER1-002-protobuf-grpc.md) — Protobuf gRPC 内部通信
+- [ADR-TIER1-003](../../docs/02_構想設計/adr/ADR-TIER1-003-language-invisibility.md) — 内部言語の不可視化
+- [docs/03_要件定義/20_機能要件/40_tier1_API契約IDL/](../../docs/03_要件定義/20_機能要件/40_tier1_API契約IDL/) — IDL 正典

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -1,0 +1,69 @@
+# src/platform — 横断ツール（Scaffold CLI / Analyzer / Backstage Plugins）
+
+tier1〜tier3 のいずれにも所属しない、開発者体験（DX）を支える横断ツール群。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/02_src配下の層別分割.md`](../../docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/02_src配下の層別分割.md)。
+
+## 配置
+
+```text
+platform/
+├── scaffold/                                       # k1s0-scaffold CLI（Rust 実装、IMP-CODEGEN-SCF-030）
+│   ├── Cargo.toml
+│   └── src/
+│       ├── main.rs                                 # CLI（list / new / new --input json --dry-run）
+│       ├── lib.rs                                  # engine 公開 API
+│       ├── template.rs                             # Backstage Software Template v1beta3 パース
+│       ├── engine.rs                               # Handlebars + walkdir 展開
+│       └── error.rs
+├── analyzer/                                       # .NET Roslyn Analyzer（IMP-DIR-ROOT-002）
+│   ├── K1s0.DependencyDirection.Analyzer.sln
+│   └── src/
+│       ├── K1s0.DependencyDirection.Analyzer/      # 本体（DiagnosticAnalyzer）
+│       ├── K1s0.DependencyDirection.Analyzer.Package/  # NuGet packaging
+│       └── tests/                                  # xUnit + Microsoft.CodeAnalysis.Testing
+└── backstage-plugins/                              # Backstage 開発者ポータル plugin（ADR-DEVEX-002）
+    ├── k1s0-catalog/                               # k1s0.io/* annotation 専用 catalog plugin
+    └── k1s0-scaffolder/                            # k1s0-scaffold の Backstage Custom Action
+```
+
+## scaffold（k1s0-scaffold CLI）
+
+```sh
+# テンプレ一覧
+k1s0-scaffold list
+
+# 対話起動
+k1s0-scaffold new tier2-go-service
+
+# CI / Backstage 経由
+k1s0-scaffold new --input '{"name":"my-svc","namespace":"k1s0"}' --dry-run
+```
+
+CLI と Backstage UI 経路（custom action `k1s0:scaffold-engine`）が**同一 engine** を呼び、生成バイトの一致を golden test で保証する（`tests/golden/scaffold-outputs/`）。
+
+## analyzer（依存方向 Roslyn Analyzer）
+
+`tier3 → tier2 → sdk → tier1` 一方向ルールを `using` 文レベルで強制する。
+診断 ID 4 件（すべて Severity=Error）:
+
+| Diagnostic ID | 違反 |
+|---|---|
+| `K1S0DEPDIR0001` | SDK → Tier2 |
+| `K1S0DEPDIR0002` | SDK → Tier3 |
+| `K1S0DEPDIR0003` | Tier2 → Tier3 |
+| `K1S0DEPDIR0004` | Tier1 → 上位層（SDK 含む） |
+
+`<ProjectReference>` レベルの違反は別途 NetArchTest（各 .sln 配下 tests/ で xUnit 化）が捕捉。
+
+## backstage-plugins
+
+`@k1s0/backstage-plugin-catalog` と `@k1s0/backstage-plugin-scaffolder` の 2 plugin。
+採用組織の Backstage バージョンへの強い依存を避けるため、OSS 側は skeleton と annotation 定数のみを提供し、
+採用組織が `@backstage/core-plugin-api` 等を import して `createPlugin` / `createTemplateAction` で接続する想定。
+
+## 関連設計
+
+- [ADR-DEV-001](../../docs/02_構想設計/adr/ADR-DEV-001-paved-road.md) — Paved Road
+- [ADR-DEVEX-002](../../docs/02_構想設計/adr/) — Backstage 採用
+- [IMP-CODEGEN-SCF-030](../../docs/05_実装/20_コード生成設計/) — Scaffold CLI
+- [IMP-DIR-ROOT-002](../../docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/05_依存方向ルール.md) — 依存方向強制

--- a/src/tier1/README.md
+++ b/src/tier1/README.md
@@ -1,0 +1,70 @@
+# src/tier1 — Go ファサード + Rust コアの Hybrid 実装（公開 12 API）
+
+ADR-TIER1-001（Go + Rust Hybrid）/ ADR-TIER1-002（Protobuf gRPC）/ ADR-TIER1-003（内部言語の不可視化）に従い、
+tier2 / tier3 から内部言語が見えない形で公開 12 API を提供する。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/20_tier1レイアウト/`](../../docs/05_実装/00_ディレクトリ設計/20_tier1レイアウト/)。
+
+## 6 Pod 構成（DS-SW-COMP-005〜010）
+
+| Pod | 言語 | 主な責務 | 公開 API |
+|---|---|---|---|
+| `t1-state` | Go | Dapr State / PubSub / Binding / ServiceInvoke / Feature の入口 + Log / Telemetry の adapter 内蔵 | State / PubSub / ServiceInvoke / Binding / Feature / Log / Telemetry |
+| `t1-secret` | Go | OpenBao 経由の Secrets API + envelope encryption | Secrets |
+| `t1-workflow` | Go | Dapr Workflow（短期）+ Temporal（長期）の振り分け | Workflow |
+| `t1-decision` | Rust | ZEN Engine 統合、JDM 評価 | Decision |
+| `t1-audit` | Rust | WORM ストア StatefulSet、ハッシュチェーン改ざん検知 | Audit |
+| `t1-pii` | Rust | PII 分類・マスキング（純関数ステートレス） | Pii |
+
+## 配置
+
+```text
+tier1/
+├── go/                                    # Dapr Go ファサード（3 Pod）
+│   ├── go.mod
+│   ├── cmd/
+│   │   ├── state/main.go                  # t1-state 起動
+│   │   ├── secret/main.go                 # t1-secret 起動
+│   │   └── workflow/main.go               # t1-workflow 起動
+│   ├── internal/
+│   │   ├── common/                        # gRPC bootstrap / config / retry / timeout
+│   │   ├── otel/                          # OpenTelemetry 初期化
+│   │   ├── adapter/dapr/                  # Dapr SDK adapter（5 building block 別）
+│   │   ├── state/                         # State + PubSub + Binding + Invoke + Feature handler
+│   │   ├── secret/                        # Secrets handler
+│   │   └── workflow/                      # Workflow handler
+│   └── proto/v1/                          # buf 生成 internal proto stub
+└── rust/                                  # Rust core（3 Pod）
+    ├── Cargo.toml                         # workspace（edition 2024）
+    ├── crates/
+    │   ├── decision/                      # k1s0-tier1-decision（main.rs + ZEN Engine 統合予定）
+    │   ├── audit/                         # k1s0-tier1-audit（main.rs + WORM 統合予定）
+    │   ├── pii/                           # k1s0-tier1-pii（main.rs + PII 検出予定）
+    │   ├── proto-gen/                     # buf 生成 internal proto を Rust module 階層に束ねる
+    │   ├── common/                        # 共通 runtime（plan 04-08 で実装）
+    │   ├── otel-util/                     # OTel 初期化（plan 04-08）
+    │   ├── policy/                        # ポリシー評価（plan 04-08）
+    │   └── proto/                         # 公開 proto stub（plan 04-08）
+    └── Dockerfile.{decision,audit,pii}
+```
+
+## ローカル起動
+
+```sh
+# 4. contracts を再生成して tier1 facade のいずれかを起動
+buf generate
+cd src/tier1/go && go run ./cmd/state           # State + PubSub + 3 API を全部
+# or: go run ./cmd/secret                       # Secrets API
+# or: go run ./cmd/workflow                     # Workflow API
+
+# Rust 側は別プロセスで起動
+cd src/tier1/rust && cargo run -p k1s0-tier1-decision   # Decision API
+# or: cargo run -p k1s0-tier1-audit
+# or: cargo run -p k1s0-tier1-pii
+```
+
+## 関連設計
+
+- [ADR-TIER1-001](../../docs/02_構想設計/adr/ADR-TIER1-001-go-rust-hybrid.md) — Go + Rust Hybrid
+- [ADR-TIER1-002](../../docs/02_構想設計/adr/ADR-TIER1-002-protobuf-grpc.md) — Protobuf gRPC
+- [ADR-TIER1-003](../../docs/02_構想設計/adr/ADR-TIER1-003-language-invisibility.md) — 内部言語不可視化
+- [docs/04_概要設計/20_ソフトウェア方式設計/01_コンポーネント方式設計/01_tier1全体コンポーネント俯瞰.md](../../docs/04_概要設計/20_ソフトウェア方式設計/01_コンポーネント方式設計/01_tier1全体コンポーネント俯瞰.md)

--- a/src/tier2/README.md
+++ b/src/tier2/README.md
@@ -1,0 +1,73 @@
+# src/tier2 — ドメイン共通業務ロジック（C# / Go）
+
+tier1 公開 API（`k1s0.State.Save` / `k1s0.PubSub.Publish` 等）の上に、複数のドメインで共有される
+業務ロジック層を構築する。tier1 の SDK のみを通して内部実装に依存し、tier3 から見ても
+**Dapr / Rust / Postgres / Kafka などのバックエンドは不可視**。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/35_tier2レイアウト/`](../../docs/05_実装/00_ディレクトリ設計/35_tier2レイアウト/)。
+
+## 配置
+
+```text
+tier2/
+├── dotnet/services/                       # C# / .NET Aspire ベースのドメインサービス
+│   ├── ApprovalFlow/                      # 承認フロー
+│   ├── InvoiceGenerator/                  # 請求書生成
+│   └── TaxCalculator/                     # 税額計算
+├── go/services/                           # Go ベースのドメインサービス
+│   ├── notification-hub/                  # 通知配信ハブ
+│   └── stock-reconciler/                  # 在庫整合
+└── templates/                             # k1s0-scaffold が参照する Backstage Software Template v1beta3
+    ├── go-service/
+    └── dotnet-service/
+```
+
+## 各サービスの構造（DDD レイヤード）
+
+```text
+<service>/
+├── <Service>.sln                           # ソリューション
+├── Dockerfile                              # distroless multi-stage
+├── catalog-info.yaml                       # Backstage カタログ
+├── README.md
+├── src/
+│   ├── <Service>.Domain/                   # ドメイン層（Entities / ValueObjects / Events / Interfaces）
+│   ├── <Service>.Application/              # アプリケーション層（UseCases）
+│   ├── <Service>.Infrastructure/           # インフラ層（Persistence、外部 API 呼び出し）
+│   └── <Service>.Api/                      # ASP.NET Core minimal API（または Go cmd）
+└── tests/
+    ├── <Service>.Domain.Tests/             # xUnit ドメイン単体
+    ├── <Service>.Application.Tests/        # ユースケース単体
+    └── <Service>.ArchitectureTests/        # NetArchTest によるレイヤ違反検出
+```
+
+Go 側は `cmd/<service>/main.go` + `internal/{api,config}/` 構成（より軽量）。
+
+## 言語選択指針（DS-SW-COMP-016）
+
+| 観点 | C# / .NET 採用 | Go 採用 |
+|---|---|---|
+| 既存 .NET 資産再利用 | ◎ | × |
+| 並行処理重視（goroutine 1 万超） | × | ◎ |
+| 業務ロジックの重さ | ◎（DDD と相性良好） | △（純粋業務は省略形になりがち） |
+| バイナリサイズ最適化 | △ | ◎（distroless 20MB） |
+
+## tier1 SDK の使い方
+
+```csharp
+// tier2 / tier3（C#）— Dapr は見えない
+await k1s0.State.SaveAsync("orders", orderId, order);
+await k1s0.PubSub.PublishAsync("order-events", "created", order);
+var decision = await k1s0.Decision.EvaluateAsync("approval/purchase", new { amount, grade });
+```
+
+```go
+// Go — 同じ動詞、同じ形
+k1s0.State.Save(ctx, "orders", orderId, order)
+k1s0.PubSub.Publish(ctx, "order-events", "created", order)
+```
+
+## 関連設計
+
+- [ADR-TIER1-003](../../docs/02_構想設計/adr/ADR-TIER1-003-language-invisibility.md) — 内部言語不可視化
+- [docs/04_概要設計/20_ソフトウェア方式設計/01_コンポーネント方式設計/](../../docs/04_概要設計/20_ソフトウェア方式設計/01_コンポーネント方式設計/) — DS-SW-COMP-016 系
+- [docs/05_実装/00_ディレクトリ設計/35_tier2レイアウト/](../../docs/05_実装/00_ディレクトリ設計/35_tier2レイアウト/)

--- a/src/tier3/README.md
+++ b/src/tier3/README.md
@@ -1,0 +1,71 @@
+# src/tier3 — UI / BFF / Native / Legacy Wrap
+
+エンドユーザに最も近い層。Web SPA・Native アプリ・BFF（Backend for Frontend）・
+.NET Framework モノリスのサイドカー方式相乗りを束ねる。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/40_tier3レイアウト/`](../../docs/05_実装/00_ディレクトリ設計/40_tier3レイアウト/)。
+
+## 配置
+
+```text
+tier3/
+├── web/                                   # React + Vite + pnpm（pnpm workspace）
+│   ├── apps/
+│   │   ├── portal/                        # 利用者ポータル
+│   │   ├── admin/                         # 管理者画面
+│   │   └── docs-site/                     # 採用ドキュメントサイト
+│   ├── packages/                          # 共通ライブラリ
+│   │   ├── ui/                            # 共通 React コンポーネント（Button / Card / Spinner ...）
+│   │   ├── api-client/                    # tier1 SDK（TypeScript）への薄ラッパ
+│   │   ├── i18n/                          # 多言語対応（ja / en の最低 2 ロケール）
+│   │   └── config/                        # 環境別設定（VITE_BFF_URL 等）
+│   └── tools/eslint-config/               # 共通 ESLint config
+├── bff/                                   # Go BFF（GraphQL）
+│   ├── go.mod
+│   ├── cmd/{portal-bff,admin-bff}/main.go
+│   └── internal/{auth,config,graphql,k1s0client,rest,shared}/
+├── native/                                # .NET MAUI（Android / iOS / macOS / Windows）
+│   ├── Native.sln
+│   ├── apps/
+│   │   ├── K1s0.Native.Hub/               # 一般利用者向け
+│   │   └── K1s0.Native.Admin/             # 管理者向け
+│   └── shared/K1s0.Native.Shared/         # 共通ロジック（Converter / Extension）
+├── legacy-wrap/                           # .NET Framework モノリスのサイドカー方式
+│   ├── LegacyWrap.sln
+│   ├── sidecars/K1s0.Legacy.Sidecar/      # ASP.NET Web API サイドカー
+│   └── migration-guide/                   # 段階的移行ガイド
+└── templates/                             # k1s0-scaffold 用テンプレ
+    ├── bff/
+    └── web/
+```
+
+## アーキテクチャ要点
+
+- **BFF パターン**: web / native は BFF（`portal-bff` / `admin-bff`）経由で tier1 を叩く。
+  認証（Keycloak OIDC）と aggregation を BFF に集約し、フロントは画面遷移と表示に集中する。
+- **k1s0.io annotation prefix**: catalog-info.yaml で `k1s0.io/component` 等の独自 annotation を使用。
+  Backstage プラグイン `k1s0-catalog` がこれをサーチ・表示する。
+- **OIDC bearer の中継**: BFF は incoming `Authorization: Bearer <token>` を tier1 へ伝搬する
+  pass-through middleware を提供（`internal/auth/middleware.go`）。
+
+## ローカル起動
+
+```sh
+# Web（pnpm 必須）
+cd src/tier3/web
+pnpm install
+pnpm --filter portal dev          # http://localhost:5173
+
+# BFF（Go）
+cd src/tier3/bff
+go run ./cmd/portal-bff           # http://localhost:8080
+
+# Native（dotnet 8.0 + MAUI workload）
+cd src/tier3/native
+dotnet build apps/K1s0.Native.Hub
+```
+
+## 関連設計
+
+- [docs/04_概要設計/20_ソフトウェア方式設計/01_コンポーネント方式設計/](../../docs/04_概要設計/20_ソフトウェア方式設計/01_コンポーネント方式設計/) — DS-SW-COMP-020 系
+- [docs/05_実装/00_ディレクトリ設計/40_tier3レイアウト/](../../docs/05_実装/00_ディレクトリ設計/40_tier3レイアウト/)
+- [ADR-MIG-001](../../docs/02_構想設計/adr/ADR-MIG-001-dotnet-sidecar.md) — .NET Framework サイドカー

--- a/src/tier3/bff/internal/rest/router.go
+++ b/src/tier3/bff/internal/rest/router.go
@@ -1,4 +1,5 @@
-// REST endpoint。
+// 本ファイルは portal-bff / admin-bff 共通の REST エンドポイント定義。
+// `/healthz` `/readyz` の k8s probe と JSON エラー応答ヘルパを束ねる。
 
 // Package rest は portal-bff / admin-bff 共通の REST エンドポイントを提供する。
 package rest

--- a/src/tier3/native/apps/K1s0.Native.Admin/App.xaml.cs
+++ b/src/tier3/native/apps/K1s0.Native.Admin/App.xaml.cs
@@ -1,3 +1,6 @@
+// 本ファイルは K1s0.Native.Admin（MAUI 管理者アプリ）のエントリ Application クラス。
+// XAML を伴わない最小実装で、ウィンドウ初期化と暫定 ContentPage の組み立てを担う。
+
 namespace K1s0.Native.Admin;
 
 public partial class App : Application

--- a/src/tier3/native/apps/K1s0.Native.Admin/Platforms/Android/MainActivity.cs
+++ b/src/tier3/native/apps/K1s0.Native.Admin/Platforms/Android/MainActivity.cs
@@ -1,3 +1,6 @@
+// 本ファイルは Android プラットフォームの起動 Activity 定義。
+// MAUI の MauiAppCompatActivity を継承し、SplashTheme と画面回転設定を Android に伝える。
+
 using Android.App;
 using Android.Content.PM;
 

--- a/src/tier3/native/apps/K1s0.Native.Admin/Platforms/Android/MainApplication.cs
+++ b/src/tier3/native/apps/K1s0.Native.Admin/Platforms/Android/MainApplication.cs
@@ -1,3 +1,6 @@
+// 本ファイルは Android プラットフォームの Application クラス。
+// MauiApplication を継承し、`MauiProgram.CreateMauiApp()` を Android から起動する責務を持つ。
+
 using Android.App;
 using Android.Runtime;
 

--- a/src/tier3/native/apps/K1s0.Native.Admin/Platforms/iOS/AppDelegate.cs
+++ b/src/tier3/native/apps/K1s0.Native.Admin/Platforms/iOS/AppDelegate.cs
@@ -1,3 +1,6 @@
+// 本ファイルは iOS プラットフォームの AppDelegate 定義。
+// MauiUIApplicationDelegate を継承し、`MauiProgram.CreateMauiApp()` を iOS から起動する。
+
 using Foundation;
 
 namespace K1s0.Native.Admin;

--- a/src/tier3/native/apps/K1s0.Native.Admin/Platforms/iOS/Program.cs
+++ b/src/tier3/native/apps/K1s0.Native.Admin/Platforms/iOS/Program.cs
@@ -1,3 +1,6 @@
+// 本ファイルは iOS プラットフォームのエントリポイント。
+// UIApplication.Main で AppDelegate を起動するだけの最小実装。
+
 using ObjCRuntime;
 using UIKit;
 

--- a/src/tier3/native/apps/K1s0.Native.Hub/AppShell.xaml.cs
+++ b/src/tier3/native/apps/K1s0.Native.Hub/AppShell.xaml.cs
@@ -1,4 +1,5 @@
-// MAUI Shell。
+// 本ファイルは K1s0.Native.Hub の MAUI Shell（タブ／フライアウト構造の親要素）定義。
+// 対応する XAML（AppShell.xaml）から InitializeComponent でルーティング情報を読み込む。
 
 namespace K1s0.Native.Hub;
 

--- a/src/tier3/web/apps/admin/src/vite-env.d.ts
+++ b/src/tier3/web/apps/admin/src/vite-env.d.ts
@@ -1,3 +1,5 @@
+// 本ファイルは admin web アプリ向け Vite の `import.meta.env` 型補完。
+// Vite client 型を拡張して環境別変数（VITE_BFF_URL 等）を strict に型付けする。
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {

--- a/src/tier3/web/apps/docs-site/src/App.test.tsx
+++ b/src/tier3/web/apps/docs-site/src/App.test.tsx
@@ -1,3 +1,6 @@
+// 本ファイルは docs-site の App コンポーネントの最小単体テスト。
+// vitest 環境で App エクスポートが関数として配置されていることを確認する。
+
 import { describe, it, expect } from 'vitest';
 import { App } from './App';
 

--- a/src/tier3/web/apps/docs-site/src/vite-env.d.ts
+++ b/src/tier3/web/apps/docs-site/src/vite-env.d.ts
@@ -1,1 +1,4 @@
+// 本ファイルは docs-site web アプリ向け Vite の型補完エントリ。
+// Vite client 型をそのまま参照するだけで、追加の env 変数定義は持たない。
 /// <reference types="vite/client" />
+export {};

--- a/src/tier3/web/apps/portal/src/vite-env.d.ts
+++ b/src/tier3/web/apps/portal/src/vite-env.d.ts
@@ -1,6 +1,7 @@
+// 本ファイルは portal web アプリ向け Vite の `import.meta.env` 型補完。
+// 環境別に注入される VITE_* 変数を strict に型付けし、コード側の参照ミスを防ぐ。
 /// <reference types="vite/client" />
 
-// Vite の import.meta.env への型補完。
 interface ImportMetaEnv {
   readonly VITE_BFF_URL: string;
   readonly VITE_TENANT_ID: string;

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,68 @@
+# tools — 横断ツール（local-stack / devcontainer / codegen / sparse / git-hooks / ci）
+
+開発者体験（DX）と CI を支える横断ツール群。
+詳細設計は [`docs/05_実装/00_ディレクトリ設計/70_共通資産/01_tools配置.md`](../docs/05_実装/00_ディレクトリ設計/70_共通資産/01_tools配置.md)。
+
+## 配置
+
+```text
+tools/
+├── README.md                                       # 本ファイル
+├── _link_check.py                                  # docs 横断リンクチェッカ
+├── _link_fix.py                                    # docs リンク自動修正
+├── _export_svg.py                                  # drawio → SVG 一括 export
+├── local-stack/                                    # kind ベース本番再現スタック（IMP-DEV-POL-006）
+│   ├── up.sh / down.sh / status.sh
+│   ├── kind-cluster.yaml
+│   └── manifests/{20..95}_*/                       # 17 レイヤ namespace yaml
+├── devcontainer/                                   # 10 役 Dev Container プロファイル
+│   ├── postCreate.sh / doctor.sh / README.md
+│   └── profiles/{tier1-rust-dev, tier2-dev, ...}/
+├── codegen/                                        # buf / openapi / grpc-docs 生成ラッパ
+│   ├── buf/run.sh                                  # buf generate + lint + breaking
+│   ├── openapi/run.sh                              # proto → OpenAPI v2 export
+│   └── grpc-docs/run.sh                            # proto → gRPC reference Markdown
+├── sparse/                                         # sparse-checkout 10 役 cone 定義
+│   ├── checkout-role.sh / verify.sh
+│   └── cones/{tier1-rust-dev, ...}.txt
+├── git-hooks/                                      # 自作 pre-commit hook
+│   ├── japanese-header-guard.py                    # 日本語ヘッダコメント強制（src/CLAUDE.md）
+│   ├── file-length-guard.py                        # 1 ファイル 500 行以内強制
+│   ├── drawio-svg-staleness.sh                     # drawio 更新後 SVG 未 export 検知
+│   └── link-check-wrapper.py                       # docs リンクチェック wrapper
+├── ci/                                             # 内製 CI linter
+│   ├── go-dep-check/                               # Go 側 依存方向 linter（独立 go.mod）
+│   └── rust-dep-check/                             # Rust 側 依存方向 linter
+└── migration/                                      # .NET Framework → .NET 8 移行支援
+```
+
+## ローカル開発の起点
+
+```sh
+# 役割を選んで sparse-checkout
+./tools/sparse/checkout-role.sh tier1-rust-dev
+
+# kind ベースのインフラを起動
+./tools/local-stack/up.sh
+
+# 自作 CLI / コード生成
+./tools/codegen/buf/run.sh                  # contracts → 4 SDK 再生成
+./tools/codegen/openapi/run.sh --check      # OpenAPI 差分チェック
+```
+
+## CI ゲート連携
+
+| Hook / linter | 役割 | 失敗時の動作 |
+|---|---|---|
+| `japanese-header-guard.py` | 日本語ヘッダコメント | pre-commit で reject |
+| `file-length-guard.py` | 500 行制限 | pre-commit で reject |
+| `drawio-svg-staleness.sh` | drawio 更新時 SVG 自動 export | pre-commit で reject |
+| `go-dep-check` | tier 越境 import 禁止 | CI で reject |
+| `rust-dep-check` | Cargo.toml の path 依存違反 | CI で reject |
+
+## 関連設計
+
+- [docs/05_実装/00_ディレクトリ設計/70_共通資産/01_tools配置.md](../docs/05_実装/00_ディレクトリ設計/70_共通資産/01_tools配置.md)
+- [ADR-DEV-001](../docs/02_構想設計/adr/ADR-DEV-001-paved-road.md) — Paved Road
+- [IMP-DEV-POL-006](../docs/05_実装/) — local-stack ベース DX
+- [IMP-DIR-ROOT-002](../docs/05_実装/00_ディレクトリ設計/10_ルートレイアウト/05_依存方向ルール.md) — 依存方向強制

--- a/tools/scorecard/at-coverage.sh
+++ b/tools/scorecard/at-coverage.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# 本ファイルは AnalysisTemplate カバレッジ計測スクリプト（IMP-REL-AT-048）。
+# 月次バッチで全サービスの AnalysisTemplate / Rollout を走査し、
+# 共通 5 本（at-common-*）と固有テンプレの参照状況から SLI カバレッジを算出する。
+# カバレッジ 70% 未満のサービスは Backstage TechInsights Scorecard に warning 表示し、
+# `docs/04_概要設計/60_観測性設計/` の SLO 設計レビュー対象として候補出しする。
+#
+# 出力: stdout に JSON Lines 形式で 1 サービス 1 レコード、Backstage TechInsights が parse する。
+#   {"service": "tier1-state", "namespace": "k1s0-tier1", "common_count": 5, "specific_count": 1,
+#    "coverage": 0.83, "verdict": "ok"}
+#
+# 詳細設計: docs/05_実装/70_リリース設計/40_AnalysisTemplate/01_AnalysisTemplate設計.md
+#
+# usage:
+#   tools/scorecard/at-coverage.sh                    # 全 namespace 走査
+#   tools/scorecard/at-coverage.sh --namespace k1s0-tier1
+#   tools/scorecard/at-coverage.sh --output /tmp/at-coverage.jsonl
+#   tools/scorecard/at-coverage.sh --threshold 0.7    # warn しきい値変更
+set -euo pipefail
+
+# 既定値。
+NAMESPACE_FILTER=""
+OUTPUT_PATH="-"
+THRESHOLD="0.7"
+COMMON_TEMPLATES=(
+  "at-common-error-rate"
+  "at-common-latency-p99"
+  "at-common-cpu"
+  "at-common-dependency-down"
+  "at-common-error-budget-burn"
+)
+
+# CLI フラグの解析。
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --namespace)
+      # 単一 namespace を対象にする。
+      NAMESPACE_FILTER="$2"
+      shift 2
+      ;;
+    --output)
+      # 出力先（- は stdout）。
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    --threshold)
+      # warning しきい値（小数）。
+      THRESHOLD="$2"
+      shift 2
+      ;;
+    --help|-h)
+      # ヘルプ表示。
+      grep '^# ' "$0" | sed 's/^# //'
+      exit 0
+      ;;
+    *)
+      # 未知フラグはエラー。
+      echo "unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# 必須コマンドの存在確認。
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "required command missing: $1" >&2; exit 3; }
+}
+require_cmd kubectl
+require_cmd jq
+
+# 出力先のセットアップ。
+if [ "$OUTPUT_PATH" != "-" ]; then
+  exec >"$OUTPUT_PATH"
+fi
+
+# Rollout を持つ namespace を列挙。
+list_namespaces() {
+  if [ -n "$NAMESPACE_FILTER" ]; then
+    echo "$NAMESPACE_FILTER"
+  else
+    kubectl get rollouts -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | sort -u
+  fi
+}
+
+# 単一 Rollout のカバレッジを評価する。
+emit_one() {
+  local ns="$1"
+  local name="$2"
+  # Rollout の analysis.templates 配列を取得。
+  local raw
+  raw="$(kubectl get rollout -n "$ns" "$name" -o json 2>/dev/null || true)"
+  if [ -z "$raw" ]; then
+    return
+  fi
+
+  # 参照されている template 名を抽出。
+  local refs
+  refs="$(printf '%s' "$raw" | jq -r '
+      [
+        (.spec.strategy.canary.steps // [])[] | select(.analysis != null) |
+        .analysis.templates[] | .templateName
+      ] | unique | .[]
+    ' 2>/dev/null || true)"
+
+  # 共通テンプレ参照数をカウント。
+  local common=0
+  for t in "${COMMON_TEMPLATES[@]}"; do
+    if printf '%s\n' "$refs" | grep -qx "$t"; then
+      common=$((common + 1))
+    fi
+  done
+
+  # 固有テンプレ数（共通でない参照）。
+  local specific=0
+  while IFS= read -r r; do
+    [ -z "$r" ] && continue
+    if ! printf '%s ' "${COMMON_TEMPLATES[@]}" | grep -qw "$r"; then
+      specific=$((specific + 1))
+    fi
+  done <<< "$refs"
+
+  # カバレッジは「共通 5 本のうちいくつ参照しているか」を 5 で割って 0〜1 に正規化。
+  # 固有テンプレは加点しない（共通の SLI 軸 5 つを満たすことを最重視する設計）。
+  local coverage
+  coverage="$(awk -v c="$common" 'BEGIN { printf "%.4f", c/5 }')"
+
+  # しきい値判定。
+  local verdict="ok"
+  if awk -v c="$coverage" -v t="$THRESHOLD" 'BEGIN { exit !(c<t) }'; then
+    verdict="warn"
+  fi
+
+  # JSON Lines を出力。
+  jq -nc --arg ns "$ns" --arg name "$name" \
+        --argjson common "$common" --argjson specific "$specific" \
+        --arg coverage "$coverage" --arg verdict "$verdict" \
+        '{namespace:$ns, service:$name, common_count:$common, specific_count:$specific,
+          coverage:($coverage|tonumber), verdict:$verdict}'
+}
+
+# メイン: 各 namespace の Rollout を順次評価。
+list_namespaces | while IFS= read -r ns; do
+  [ -z "$ns" ] && continue
+  kubectl get rollouts -n "$ns" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+    | while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        emit_one "$ns" "$name"
+      done
+done


### PR DESCRIPTION
## Summary

- **OSS として docs 設計が忠実に実装されているか** を全領域で監査し、設計と乖離していた 5 領域を一括是正
- **残「設計のみ」は `deploy/opentofu/` と `deploy/rollouts/experiments/` の 2 件のみ**（両方とも docs 上「採用後の運用拡大時」マーク）に到達
- `tools/git-hooks/{japanese-header-guard,file-length-guard}.py` を全変更ファイル（49 件）で OK 通過

## 是正対象（5 commits）

| # | コミット | 種別 | 解消したギャップ |
|---|---|---|---|
| 1 | `a27d14c4` | fix | 直近 7 commits 由来の日本語ヘッダ 11 件未付与（`src/CLAUDE.md` 規約違反） |
| 2 | `cab29a54` | feat | `infra/mesh/envoy-gateway/` が `.gitkeep` のみ（ADR-CNCF-004 / IMP-DIR-INFRA-073 が要求する 7 ファイル不在） |
| 3 | `a39b934d` | feat | `deploy/rollouts/analysis/` 配下の共通 ClusterAnalysisTemplate 5 本未配置（IMP-REL-AT-040〜049）、`tools/scorecard/at-coverage.sh` 不在（IMP-REL-AT-048） |
| 4 | `80604c1d` | feat | `deploy/apps/app-of-apps.yaml` / `application-sets/{infra,ops}.yaml` / `projects/{k1s0-platform,rbac}.yaml` 不在（IMP-DIR-OPS-092）、`deploy/charts/predeploy-hooks/` 「リリース時点 で整備」マークのまま空 |
| 5 | `ec144dc8` | docs | ルート README 9 件未配置（IMP-DIR-COMM-110）、`SHIP_STATUS.md` が `6064ba70` で誤って削除されたまま（README 導線が壊れていた） |

## 主な実装内容

### infra/mesh/envoy-gateway（commit 2）

ADR-CNCF-004 / `03_サービスメッシュ配置.md` 仕様準拠:
- `values.yaml`（HA 3 + OTel tracing 連携 + Prometheus ServiceMonitor）
- `gatewayclass-envoy.yaml`
- `gateway-public.yaml`（MetalLB + cert-manager letsencrypt-prod TLS、`api.k1s0.internal` + `app.k1s0.internal`）
- `gateway-internal.yaml`（VPN/Bastion 内部公開、`ops.k1s0.internal` + `portal.k1s0.internal`）
- `httproute/{tier1-api,tier3-web,redirect-http-to-https}.yaml`（tier1 12 API path 振り分け + tier3 SPA/BFF + 80→443 リダイレクト）
- `README.md`（採用理由 / dev-prod 差分表 / Istio Ambient との責務分離）

### deploy/rollouts/analysis 共通 5 本（commit 3）

IMP-REL-AT-040〜049 仕様準拠の `ClusterAnalysisTemplate`（cluster スコープ）:
- `at-common-error-rate`（baseline 2σ 超過、failureLimit 2 / count 5）
- `at-common-latency-p99`（args 渡し SLO 値超過）
- `at-common-cpu`（80% 10 分中 8 分継続）
- `at-common-dependency-down`（Postgres/Kafka/Valkey の `up` 0 で短絡判定）
- `at-common-error-budget-burn`（`api:burn_rate_1h` 2x 超過）
- `tools/scorecard/at-coverage.sh`（kubectl + jq で全 Rollout 走査、JSON Lines 出力、--namespace / --output / --threshold フラグ対応）

### deploy/apps GitOps ルート + predeploy-hooks（commit 4）

- `app-of-apps.yaml`（Argo CD 初期化時に唯一手動 apply するルート）
- `application-sets/infra.yaml`（list-generator で dev/staging/prod を Wave -10 で配備）
- `application-sets/ops.yaml`（backstage / chaos / runbooks を Wave 40〜45 で配備）
- `projects/k1s0-platform.yaml`（umbrella AppProject、cluster 級リソース全許可、admin/viewer ロール）
- `projects/rbac.yaml`（Keycloak OIDC `groups` claim → 5 ロール写像）
- `charts/predeploy-hooks/`（PreSync Hook Job 4 種: pg_isready / nc -z / valkey-cli ping / curl `/minio/health/ready`、PSS restricted 準拠）

### ルート README 10 件 + SHIP_STATUS（commit 5）

IMP-DIR-COMM-110 が要求する直下サブディレクトリ README 9 件を新規配置（`src/`, `src/contracts/`, `src/tier1/`, `src/tier2/`, `src/tier3/`, `src/platform/`, `infra/`, `ops/`, `tools/`）+ `deploy/README.md` を新規配置。`docs/SHIP_STATUS.md` は `6064ba70` で誤った commit message と共に削除されていたものを最新の実装状態で再構築。

## docs 設計との整合性

すべての変更が以下の docs 正典と直接対応:

- ADR-CNCF-004 / ADR-DIR-002 / ADR-CICD-001 / ADR-CICD-002 / ADR-REL-001 / ADR-OBS-001
- IMP-DIR-INFRA-073（サービスメッシュ配置）
- IMP-DIR-OPS-092（ApplicationSet 配置）
- IMP-DIR-COMM-110（ドキュメント近接配置）
- IMP-REL-AT-040〜049（共通 AnalysisTemplate）
- DS-SW-COMP-005〜010（tier1 6 Pod 構成）

## Test plan

- [x] `tools/git-hooks/file-length-guard.py` を全 49 変更ファイルで通過（500 行制限）
- [x] `tools/git-hooks/japanese-header-guard.py` を全 12 コードファイルで通過（先頭日本語コメント）
- [ ] CI: `buf lint` / `buf breaking` 通過（contracts 無変更のため自動 skip 想定）
- [ ] CI: yaml lint（kustomize / Helm chart の構文検証）
- [ ] CI: markdownlint（10 README + SHIP_STATUS）
- [ ] 手動: Argo CD クラスタに `app-of-apps.yaml` を apply して全 ApplicationSet が展開されることを確認（採用初期段階）
- [ ] 手動: `helm template deploy/charts/predeploy-hooks/` で 4 Job manifest が生成されることを確認
- [ ] 手動: `kubectl apply --dry-run=client -f infra/mesh/envoy-gateway/` で全 Gateway API リソースが構文有効であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)